### PR TITLE
Add nodes and connections tables

### DIFF
--- a/agentflow/schema.sql
+++ b/agentflow/schema.sql
@@ -6,3 +6,32 @@ create table projects (
   node_count integer default 0,
   status text check (status in ('draft', 'testing', 'deployed'))
 );
+
+-- Table to store individual nodes that make up a project flow
+create table nodes (
+  id text primary key default uuid_generate_v4(),
+  project_id text references projects(id) on delete cascade,
+  type text not null,
+  subtype text,
+  position jsonb,
+  size jsonb,
+  data jsonb,
+  inputs jsonb,
+  outputs jsonb,
+  created_at timestamp with time zone default now()
+);
+
+-- Table linking nodes together within a project
+create table connections (
+  id text primary key default uuid_generate_v4(),
+  project_id text references projects(id) on delete cascade,
+  source_node text references nodes(id) on delete cascade,
+  source_output text,
+  target_node text references nodes(id) on delete cascade,
+  target_input text,
+  created_at timestamp with time zone default now()
+);
+
+-- Row Level Security (RLS)
+-- No RLS policies are defined in this project. Add policies here if your
+-- application requires user-based access control.


### PR DESCRIPTION
## Summary
- extend schema.sql with new `nodes` and `connections` tables
- document (lack of) row level security policies

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f73b4548832cac2d86260ac03caf