### PR TITLE
Refactor ChatBox connection handling

### DIFF
--- a/agentflow/src/components/Canvas.tsx
+++ b/agentflow/src/components/Canvas.tsx
@@ -564,6 +564,7 @@ export default function CanvasEngine(props: Props) {
                 nodes={nodes}
                 connections={connections}
                 theme={theme}
+                onOutputPortMouseDown={handlePortMouseDown}
               />
             );
           }

--- a/agentflow/src/components/ChatBoxNode.tsx
+++ b/agentflow/src/components/ChatBoxNode.tsx
@@ -11,6 +11,12 @@ interface ChatBoxNodeProps {
   nodes: CanvasNode[];
   connections: Connection[];
   theme: Colors;
+  onOutputPortMouseDown: (
+    e: React.MouseEvent,
+    nodeId: string,
+    outputId: string,
+    index: number
+  ) => void;
 }
 
 export default function ChatBoxNode(props: ChatBoxNodeProps) {
@@ -23,7 +29,8 @@ export default function ChatBoxNode(props: ChatBoxNodeProps) {
     onNodeUpdate,
     nodes,
     connections,
-    theme
+    theme,
+    onOutputPortMouseDown
   } = props;
 
   const chatData = node.data as ChatNodeData;
@@ -114,12 +121,7 @@ export default function ChatBoxNode(props: ChatBoxNodeProps) {
           }}
           onMouseDown={e => {
             e.stopPropagation();
-            if (props.onNodeMouseDown) props.onNodeMouseDown(e, node.id);
-            // Call canvas connection drag logic if available
-            const win = window as Window & { handlePortMouseDown?: (e: React.MouseEvent, nodeId: string, outputId: string, index: number) => void };
-            if (typeof win.handlePortMouseDown === 'function') {
-              win.handlePortMouseDown(e, node.id, output.id, index);
-            }
+            onOutputPortMouseDown(e, node.id, output.id, index);
           }}
           title={output.label}
         />


### PR DESCRIPTION
## Summary
- remove global `window.handlePortMouseDown` call in `ChatBoxNode`
- add `onOutputPortMouseDown` prop to `ChatBoxNode`
- pass `handlePortMouseDown` from `Canvas` to each chat box node

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6884f73e16d4832caaba93bb7fa527a0