### PR TITLE
Add error for missing Gemini API key

### DIFF
--- a/agentflow/README.md
+++ b/agentflow/README.md
@@ -18,7 +18,12 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+## Environment Variables
+
+Set `NEXT_PUBLIC_GEMINI_API_KEY` in your environment (for example in `.env.local`) with your Gemini API key.
 
 ## Learn More
 

--- a/agentflow/src/lib/geminiClient.ts
+++ b/agentflow/src/lib/geminiClient.ts
@@ -1,7 +1,9 @@
 // Gemini API utility for workflow execution
-// Replace 'YOUR_GEMINI_API_KEY' with your actual key in production
-
-const GEMINI_API_KEY = process.env.NEXT_PUBLIC_GEMINI_API_KEY || 'YOUR_GEMINI_API_KEY';
+// Throw an explicit error if the API key is missing
+const GEMINI_API_KEY = process.env.NEXT_PUBLIC_GEMINI_API_KEY;
+if (!GEMINI_API_KEY) {
+  throw new Error('NEXT_PUBLIC_GEMINI_API_KEY environment variable is required');
+}
 const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent';
 
 export async function callGemini(prompt: string, params: Record<string, unknown> = {}) {


### PR DESCRIPTION
## Summary
- add runtime check for `NEXT_PUBLIC_GEMINI_API_KEY` in `geminiClient`
- document required env var in the README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f7415f20832c8ca4677da8251c42