### PR TITLE
style: apply figma scrollbar class

### DIFF
--- a/agentflow/src/components/AgentSidebar.tsx
+++ b/agentflow/src/components/AgentSidebar.tsx
@@ -78,7 +78,7 @@ export function AgentSidebar() {
         </p>
       </div>
       
-      <div className="p-4 space-y-4 h-full overflow-auto">
+      <div className="p-4 space-y-4 h-full overflow-auto figma-scrollbar">
         <div>
           <h3 className="font-medium mb-3 text-sm">Core Agents</h3>
           <div className="space-y-2">

--- a/agentflow/src/components/CompactPropertiesPanel.tsx
+++ b/agentflow/src/components/CompactPropertiesPanel.tsx
@@ -67,7 +67,7 @@ export default function CompactPropertiesPanel({
   // Empty state when no node is selected
   if (!selectedNode) {
     return (
-      <div style={panelStyle}>
+      <div style={panelStyle} className="figma-scrollbar">
         <div
           style={{
             padding: "24px 16px",
@@ -158,7 +158,7 @@ export default function CompactPropertiesPanel({
 
   // Unknown node type fallback with compact, theme-driven styling
   const renderUnknownNodePanel = () => (
-    <div style={panelStyle}>
+    <div style={panelStyle} className="figma-scrollbar">
       {/* Header */}
       <div
         style={{
@@ -320,7 +320,7 @@ export default function CompactPropertiesPanel({
     const nodeType = selectedNode.subtype || selectedNode.type;
     // Wrap existing panels with compact styling
     const wrapPanel = (PanelComponent: React.ComponentType<any>) => (
-      <div style={panelStyle}>
+      <div style={panelStyle} className="figma-scrollbar">
         <PanelComponent node={selectedNode} onChange={onChange} />
       </div>
     );

--- a/agentflow/src/components/ComponentLibrary.tsx
+++ b/agentflow/src/components/ComponentLibrary.tsx
@@ -52,7 +52,7 @@ export function ComponentLibrary({ onAddNode, onBackToProjects }: ComponentLibra
         </button>
       </div>
       {/* Node Library - minimalist explorer */}
-      <div className="flex-1 overflow-auto p-4">
+      <div className="flex-1 overflow-auto figma-scrollbar p-4">
         <div className="flex items-center justify-between mb-3">
           <span className="text-xs font-semibold text-white">Components</span>
         </div>

--- a/agentflow/src/components/ConversationFlowNode.tsx
+++ b/agentflow/src/components/ConversationFlowNode.tsx
@@ -201,7 +201,7 @@ export default function ConversationFlowNode({
       </div>
 
       {/* Messages */}
-      <div className="p-3 space-y-2 max-h-[500px] overflow-y-auto">
+      <div className="p-3 space-y-2 max-h-[500px] overflow-y-auto figma-scrollbar">
         {messages.map((message, index) => (
           <div key={message.id} className="relative group">
             {/* Connection Line */}

--- a/agentflow/src/components/ConversationTester.tsx
+++ b/agentflow/src/components/ConversationTester.tsx
@@ -20,7 +20,7 @@ export default function ConversationTester({ nodes, connections, onClose }: Conv
               <button onClick={onClose} className="text-gray-400 hover:text-white">✕</button>
             )}
           </div>
-          <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          <div className="flex-1 overflow-y-auto figma-scrollbar p-6 space-y-4">
             {nodes && nodes.length > 0 ? (
               nodes.map(node => (
                 <div key={node.id} className={`flex ${node.type === 'agent' ? 'justify-start' : node.type === 'ui' ? 'justify-end' : 'justify-center'}`}>

--- a/agentflow/src/components/DesignerCanvas.tsx
+++ b/agentflow/src/components/DesignerCanvas.tsx
@@ -140,7 +140,7 @@ export default function DesignerCanvas(props: DesignerCanvasProps) {
     <div className="flex-1 relative overflow-hidden">
       {/* Real-time Test Flow Panel */}
       {testLogs.length > 0 && (
-        <div className="absolute top-16 right-4 w-96 max-h-[60vh] overflow-auto bg-[#1e1e1e] text-vscode-text p-4 rounded shadow z-20 font-mono text-xs">
+        <div className="absolute top-16 right-4 w-96 max-h-[60vh] overflow-auto figma-scrollbar bg-[#1e1e1e] text-vscode-text p-4 rounded shadow z-20 font-mono text-xs">
           <div className="font-bold text-vscode-title mb-2">Test Flow Log</div>
           {testLogs.map((log, i) => (
             <div
@@ -207,7 +207,7 @@ export default function DesignerCanvas(props: DesignerCanvasProps) {
       )}
       {/* Results Panel */}
       {testFlowResult && (
-        <div className="absolute top-16 right-4 w-96 max-h-[60vh] overflow-auto bg-gray-900 text-white p-4 rounded shadow z-20">
+        <div className="absolute top-16 right-4 w-96 max-h-[60vh] overflow-auto figma-scrollbar bg-gray-900 text-white p-4 rounded shadow z-20">
           <h4 className="font-bold mb-2">Flow Results</h4>
           <div className="space-y-3">
             {Object.entries(testFlowResult).map(([nodeId, output]) => {

--- a/agentflow/src/components/EnhancedAgentConfig.tsx
+++ b/agentflow/src/components/EnhancedAgentConfig.tsx
@@ -120,7 +120,7 @@ export default function EnhancedAgentConfig({ node, onUpdate }: AgentConfigProps
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 min-h-0 overflow-y-auto figma-scrollbar p-4 space-y-4">
         {/* Personality Tab */}
         {activeTab === 'personality' && (
           <div className="space-y-4">

--- a/agentflow/src/components/PropertiesPanel.tsx
+++ b/agentflow/src/components/PropertiesPanel.tsx
@@ -73,7 +73,7 @@ export default function CompactPropertiesPanel({
   // Empty state when no node is selected
   if (!selectedNode) {
     return (
-      <div style={panelStyle}>
+      <div style={panelStyle} className="figma-scrollbar">
         <div
           style={{
             padding: "24px 16px",
@@ -166,7 +166,7 @@ export default function CompactPropertiesPanel({
 
   // Unknown node type fallback with compact styling
   const renderUnknownNodePanel = () => (
-    <div style={panelStyle}>
+    <div style={panelStyle} className="figma-scrollbar">
       {/* Header */}
       <div
         style={{
@@ -331,7 +331,7 @@ export default function CompactPropertiesPanel({
 
     // Wrap existing panels with compact styling
     const wrapPanel = (PanelComponent: PropertyPanelComponent, nodeOverride?: CanvasNode) => (
-      <div style={panelStyle}>
+      <div style={panelStyle} className="figma-scrollbar">
         <PanelComponent node={nodeOverride ?? selectedNode} onChange={onChange} />
       </div>
     );

--- a/agentflow/src/components/ui/select.tsx
+++ b/agentflow/src/components/ui/select.tsx
@@ -61,7 +61,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto figma-scrollbar rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className

--- a/agentflow/src/components/ui/sidebar.tsx
+++ b/agentflow/src/components/ui/sidebar.tsx
@@ -374,7 +374,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto figma-scrollbar group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- apply `figma-scrollbar` class to sidebar content, component library, agent sidebar, and various panels for consistent scroll styling
- update scrollable overlays in designer canvas and conversation-related views to use shared scrollbar class

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688e662a2c94832c8b917e5e0cc803ad