### PR TITLE
fix: offset properties panel for top bar

### DIFF
--- a/agentflow/src/components/CompactPropertiesPanel.tsx
+++ b/agentflow/src/components/CompactPropertiesPanel.tsx
@@ -29,7 +29,6 @@ import ConversationFlowPropertiesPanel from "./propertiesPanels/ConversationFlow
 import SimulatorPropertiesPanel from "./propertiesPanels/SimulatorPropertiesPanel";
 import DashboardPropertiesPanel from "./propertiesPanels/DashboardPropertiesPanel";
 import ChatInterfacePropertiesPanel from "./propertiesPanels/ChatInterfacePropertiesPanel";
-import TestCasePropertiesPanel from "./propertiesPanels/TestCasePropertiesPanel";
 
 interface PropertiesPanelProps {
   selectedNode: CanvasNode | null;
@@ -40,12 +39,15 @@ export default function CompactPropertiesPanel({
   selectedNode,
   onChange,
 }: PropertiesPanelProps) {
+  // Height of the global top bar to offset the panel
+  const TOP_BAR_HEIGHT = 64;
+
   // Panel container style - fixed width, no horizontal scroll, theme-driven
   const panelStyle: React.CSSProperties = {
     width: theme.components.panel.width,
     minWidth: theme.components.panel.minWidth,
     maxWidth: theme.components.panel.maxWidth,
-    height: "100%",
+    height: `calc(100% - ${TOP_BAR_HEIGHT}px)`,
     minHeight: 0,
     display: "flex",
     flexDirection: "column",
@@ -59,7 +61,7 @@ export default function CompactPropertiesPanel({
     color: theme.colors.textPrimary,
     position: "fixed",
     right: 0,
-    top: 0,
+    top: `${TOP_BAR_HEIGHT}px`,
     zIndex: 100,
     boxSizing: "border-box",
   };
@@ -299,17 +301,17 @@ export default function CompactPropertiesPanel({
               Panel Not Available
             </h4>
           </div>
-          <p
-            style={{
-              fontSize: theme.typography.fontSize.xs,
-              color: theme.colors.textMuted,
-              margin: 0,
-              lineHeight: 1.4,
-            }}
-          >
-            Properties panel for this node type hasn't been implemented yet. The
-            node will still work in workflows.
-          </p>
+            <p
+              style={{
+                fontSize: theme.typography.fontSize.xs,
+                color: theme.colors.textMuted,
+                margin: 0,
+                lineHeight: 1.4,
+              }}
+            >
+              Properties panel for this node type hasn&apos;t been implemented yet. The
+              node will still work in workflows.
+            </p>
         </div>
       </div>
     </div>
@@ -319,11 +321,13 @@ export default function CompactPropertiesPanel({
   const renderNodePanel = () => {
     const nodeType = selectedNode.subtype || selectedNode.type;
     // Wrap existing panels with compact styling
-    const wrapPanel = (PanelComponent: React.ComponentType<any>) => (
-      <div style={panelStyle}>
-        <PanelComponent node={selectedNode} onChange={onChange} />
-      </div>
-    );
+      const wrapPanel = (
+        PanelComponent: React.ComponentType<Record<string, unknown>>
+      ) => (
+        <div style={panelStyle}>
+          <PanelComponent node={selectedNode} onChange={onChange} />
+        </div>
+      );
     switch (nodeType) {
       case "agent":
       case "generic":

--- a/agentflow/src/components/PropertiesPanel.tsx
+++ b/agentflow/src/components/PropertiesPanel.tsx
@@ -29,7 +29,6 @@ import ConversationFlowPropertiesPanel from "./propertiesPanels/ConversationFlow
 import SimulatorPropertiesPanel from "./propertiesPanels/SimulatorPropertiesPanel";
 import DashboardPropertiesPanel from "./propertiesPanels/DashboardPropertiesPanel";
 import ChatInterfacePropertiesPanel from "./propertiesPanels/ChatInterfacePropertiesPanel";
-import TestCasePropertiesPanel from "./propertiesPanels/TestCasePropertiesPanel";
 
 interface PropertiesPanelProps {
   selectedNode: CanvasNode | null;
@@ -46,12 +45,15 @@ export default function CompactPropertiesPanel({
   selectedNode,
   onChange,
 }: PropertiesPanelProps) {
+  // Height of the global top bar to offset the panel
+  const TOP_BAR_HEIGHT = 64;
+
   // Panel container style - fixed width, no horizontal scroll
   const panelStyle: React.CSSProperties = {
     width: "280px",
     minWidth: "260px",
     maxWidth: "300px",
-    height: "100%",
+    height: `calc(100% - ${TOP_BAR_HEIGHT}px)`,
     minHeight: 0,
     display: "flex",
     flexDirection: "column",
@@ -65,7 +67,7 @@ export default function CompactPropertiesPanel({
     color: "#cccccc",
     position: "fixed", // Make it feel truly fixed
     right: 0,
-    top: 0,
+    top: `${TOP_BAR_HEIGHT}px`,
     zIndex: 100,
     boxSizing: "border-box",
   };


### PR DESCRIPTION
## Summary
- ensure properties panel does not cover the global top bar by offsetting its fixed position and height
- clean up panel code by removing unused import and escaping apostrophes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: warnings/errors in existing files)*
- `npx eslint src/components/PropertiesPanel.tsx src/components/CompactPropertiesPanel.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688e66263b80832c8527f63ee9f55792