### PR TITLE
feat: add figma interaction utilities

### DIFF
--- a/agentflow/src/app/globals.css
+++ b/agentflow/src/app/globals.css
@@ -62,3 +62,25 @@
   border-radius: 3px;
 }
 
+/* Figma interaction utilities */
+@layer utilities {
+  .figma-transition {
+    @apply transition-all duration-200 ease-out;
+  }
+  .figma-transition-fast {
+    @apply transition-all duration-100 ease-out;
+  }
+  .figma-transition-slow {
+    @apply transition-all duration-300 ease-out;
+  }
+  .figma-hover-lift {
+    @apply hover:-translate-y-0.5 hover:shadow-md;
+  }
+  .figma-hover-scale {
+    @apply hover:scale-[1.02];
+  }
+  .figma-focus-ring {
+    @apply focus-visible:outline-none focus-visible:border-[var(--figma-accent)] focus-visible:ring-2 focus-visible:ring-[var(--figma-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--figma-bg)];
+  }
+}
+

--- a/agentflow/src/components/TabBar.tsx
+++ b/agentflow/src/components/TabBar.tsx
@@ -48,7 +48,7 @@ export default function TabBar({
           <div
             key={tab.id}
             onClick={() => setActiveId(tab.id)}
-            className={`group flex items-center h-6 px-2 rounded-t-md cursor-pointer select-none text-sm ${
+            className={`group flex items-center h-6 px-2 rounded-t-md cursor-pointer select-none text-sm figma-transition-slow ${
               activeId === tab.id
                 ? "bg-[var(--figma-bg)] text-[var(--figma-text)]"
                 : "text-[var(--figma-text-secondary)]"
@@ -67,7 +67,7 @@ export default function TabBar({
                 e.stopPropagation();
                 closeTab(tab.id);
               }}
-              className="ml-2 opacity-0 group-hover:opacity-100 hover:text-[var(--figma-text)]"
+              className="ml-2 opacity-0 group-hover:opacity-100 hover:text-[var(--figma-text)] figma-transition-fast figma-focus-ring"
             >
               <X className="w-3 h-3" />
             </button>
@@ -75,7 +75,7 @@ export default function TabBar({
         ))}
         <button
           onClick={addTab}
-          className="ml-1 w-6 h-6 flex items-center justify-center text-[var(--figma-text-secondary)] hover:text-[var(--figma-text)]"
+          className="ml-1 w-6 h-6 flex items-center justify-center text-[var(--figma-text-secondary)] hover:text-[var(--figma-text)] figma-transition-fast figma-hover-scale figma-focus-ring"
           title="New file"
         >
           <Plus className="w-4 h-4" />

--- a/agentflow/src/components/UserAvatar.tsx
+++ b/agentflow/src/components/UserAvatar.tsx
@@ -10,7 +10,7 @@ interface UserAvatarProps {
 
 export default function UserAvatar({ name, image, online }: UserAvatarProps) {
   return (
-    <div className="relative w-6 h-6" title={name}>
+    <div className="relative w-6 h-6 figma-transition-fast figma-hover-scale" title={name}>
       {image ? (
         <Image src={image} alt={name} fill className="rounded-full object-cover" />
       ) : (

--- a/agentflow/src/components/ui/button.tsx
+++ b/agentflow/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium figma-transition figma-hover-lift figma-focus-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/agentflow/src/components/ui/input.tsx
+++ b/agentflow/src/components/ui/input.tsx
@@ -8,8 +8,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs figma-transition file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "figma-focus-ring",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/agentflow/src/components/ui/select.tsx
+++ b/agentflow/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs figma-transition figma-focus-ring disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- add figma interaction utility classes for transitions, hover effects, and focus rings
- apply new utilities to buttons, inputs, selects, avatars, and tab controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Error: `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`; Error: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_688e66220df4832ca86e34f713e2dcae