### PR TITLE
refactor: unify node styles

### DIFF
--- a/agentflow/src/components/ChatBoxNode.tsx
+++ b/agentflow/src/components/ChatBoxNode.tsx
@@ -1,6 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { CanvasNode, Colors, Connection } from '@/types';
 import { supabase } from '@/lib/supabaseClient';
+import {
+  figmaNodeStyle,
+  selectedNodeStyle,
+  hoverNodeStyle
+} from './nodeStyles';
 
 interface ChatBoxNodeProps {
   node: CanvasNode;
@@ -42,6 +47,7 @@ export default function ChatBoxNode(props: ChatBoxNodeProps) {
 
   // Get the current input value from node data
   const [input, setInput] = useState((node.data as ChatBoxNodeData).inputValue || '');
+  const [isHovered, setIsHovered] = useState(false);
 
   // Update node data when input changes
   const handleInputChange = (value: string) => {
@@ -64,20 +70,27 @@ export default function ChatBoxNode(props: ChatBoxNodeProps) {
       .then(result => console.log('Database update result:', result)); // Add this
   };
 
+  const nodeStyle: React.CSSProperties = {
+    ...figmaNodeStyle,
+    left: node.position.x,
+    top: node.position.y,
+    width: node.size.width,
+    height: node.size.height,
+    borderColor: isSelected ? 'var(--figma-accent)' : 'var(--figma-border)',
+    ...(isHovered ? hoverNodeStyle : {}),
+    ...(isSelected ? selectedNodeStyle : {}),
+    zIndex: 3
+  };
+
   return (
     <div
-      className={`absolute flex flex-col bg-white/5 border rounded-lg shadow-lg ${isSelected ? 'ring-2 ring-blue-400' : ''}`}
-      style={{
-        left: node.position.x,
-        top: node.position.y,
-        width: node.size.width,
-        height: node.size.height,
-        borderColor: isSelected ? theme.accent : theme.border,
-        zIndex: 3
-      }}
+      className="absolute flex flex-col"
+      style={nodeStyle}
       onMouseDown={e => onNodeMouseDown(e, node.id)}
       onClick={e => onNodeClick(e, node.id)}
       onContextMenu={e => onNodeContextMenu(e, node.id)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       {/* Header */}
       <div className="flex items-center gap-2 p-2 border-b" style={{ borderColor: theme.border }}>

--- a/agentflow/src/components/ConversationFlowNode.tsx
+++ b/agentflow/src/components/ConversationFlowNode.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { MessageSquare, Plus, GitBranch, Trash2, Edit2, ChevronRight, User, Bot } from 'lucide-react';
+import {
+  figmaNodeStyle,
+  selectedNodeStyle,
+  hoverNodeStyle
+} from './nodeStyles';
 
 interface ConversationNodeData {
   messages: ConversationMessage[];
@@ -69,6 +74,7 @@ export default function ConversationFlowNode({
   const [editingMessage, setEditingMessage] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
   const [showBranchMenu, setShowBranchMenu] = useState<string | null>(null);
+  const [isHovered, setIsHovered] = useState(false);
 
   useEffect(() => {
     // Update node data when messages change
@@ -155,24 +161,27 @@ export default function ConversationFlowNode({
   // - Use subtle hover/focus effects
   // - Use monospace font for message bubbles for a professional feel
 
+  const nodeStyle: React.CSSProperties = {
+    ...figmaNodeStyle,
+    left: node.position.x,
+    top: node.position.y,
+    width: 400,
+    minHeight: 300,
+    borderColor: isSelected ? 'var(--figma-accent)' : 'var(--figma-border)',
+    zIndex: isSelected ? 10 : 5,
+    fontFamily: 'Inter, Menlo, monospace',
+    ...(isHovered ? hoverNodeStyle : {}),
+    ...(isSelected ? selectedNodeStyle : {})
+  };
+
   return (
     <div
-      className={`absolute bg-[#18181b] border border-[#23232a] overflow-hidden transition-all ${
-        isSelected ? 'ring-2 ring-blue-500 shadow-lg' : 'shadow-sm'
-      }`}
-      style={{
-        left: node.position.x,
-        top: node.position.y,
-        width: 400,
-        minHeight: 300,
-        borderRadius: 4,
-        borderColor: isSelected ? '#2563eb' : '#23232a',
-        zIndex: isSelected ? 10 : 5,
-        fontFamily: 'Inter, Menlo, monospace',
-        boxShadow: isSelected ? '0 0 0 2px #2563eb33' : '0 2px 8px #000a',
-      }}
+      className="absolute overflow-hidden transition-all"
+      style={nodeStyle}
       onMouseDown={(e) => onNodeMouseDown(e, node.id)}
       onClick={(e) => onNodeClick(e, node.id)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       {/* Header */}
       <div className="bg-[#23232a] px-3 py-2 flex items-center justify-between border-b border-[#23232a]">

--- a/agentflow/src/components/nodeStyles.ts
+++ b/agentflow/src/components/nodeStyles.ts
@@ -1,0 +1,17 @@
+import type { CSSProperties } from 'react';
+
+export const figmaNodeStyle: CSSProperties = {
+  backgroundColor: 'var(--figma-surface)',
+  border: '1px solid var(--figma-border)',
+  borderRadius: 'var(--figma-radius)',
+  boxShadow: '0 2px 8px #000a',
+  transition: 'box-shadow 0.2s ease'
+};
+
+export const selectedNodeStyle: CSSProperties = {
+  boxShadow: '0 0 0 2px var(--figma-accent), 0 2px 8px #000a'
+};
+
+export const hoverNodeStyle: CSSProperties = {
+  boxShadow: '0 0 0 2px var(--figma-border), 0 2px 8px #000a'
+};


### PR DESCRIPTION
## Summary
- add shared figmaNodeStyle, selectedNodeStyle, and hoverNodeStyle utilities for consistent node backgrounds, borders, and shadows
- refactor ChatBoxNode and ConversationFlowNode to use shared styles with hover and selection handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any & unescaped entities in other files)*

------
https://chatgpt.com/codex/tasks/task_e_688e661e9e50832cb574fbc6357d647d