### PR TITLE
feat: add layers panel to sidebar

### DIFF
--- a/agentflow/src/app/page.tsx
+++ b/agentflow/src/app/page.tsx
@@ -6,6 +6,7 @@ import { supabase } from "@/lib/supabaseClient";
 import ProjectDashboard from "@/components/ProjectDashboard";
 import DesignerLayout from "@/components/DesignerLayout";
 import { ComponentLibrary } from "@/components/ComponentLibrary";
+import LayersPanel from "@/components/LayersPanel";
 import DesignerCanvas from "@/components/DesignerCanvas";
 import PropertiesPanel from "@/components/PropertiesPanel";
 import { nodeCategories } from "@/data/nodeDefinitions";
@@ -457,10 +458,13 @@ export default function AgentFlowPage() {
   return (
     <DesignerLayout
       left={
-        <ComponentLibrary
-          onAddNode={handleAddNode}
-          onBackToProjects={() => setCurrentView("projects")}
-        />
+        <div className="flex h-full">
+          <LayersPanel nodes={nodes} />
+          <ComponentLibrary
+            onAddNode={handleAddNode}
+            onBackToProjects={() => setCurrentView("projects")}
+          />
+        </div>
       }
       center={
         <DesignerCanvas

--- a/agentflow/src/components/LayersPanel.tsx
+++ b/agentflow/src/components/LayersPanel.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Layers as LayersIcon } from "lucide-react";
+import { CanvasNode } from "@/types";
+
+interface LayersPanelProps {
+  nodes: CanvasNode[];
+}
+
+export default function LayersPanel({ nodes }: LayersPanelProps) {
+  return (
+    <aside className="w-64 border-r border-[var(--figma-border)] bg-[var(--figma-surface)] flex flex-col">
+      <div className="border-b border-[var(--figma-border)] p-[var(--space-md)]">
+        <h2 className="font-medium text-[var(--fs-sm)]">Layers</h2>
+      </div>
+      <div className="flex-1 overflow-y-auto figma-scrollbar p-[var(--space-sm)]">
+        <ul className="space-y-[var(--space-xs)]">
+          {nodes.map((node) => {
+            const title = (node.data as { title?: string }).title ?? node.id;
+
+            return (
+              <li
+                key={node.id}
+                className="flex items-center gap-[var(--space-sm)] rounded cursor-pointer hover:bg-[var(--figma-bg)] px-[var(--space-sm)] py-[var(--space-xs)] text-[var(--fs-sm)]"
+              >
+                <LayersIcon className="w-4 h-4 text-[var(--figma-text-secondary)]" />
+                <span className="truncate">{title}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add LayersPanel component with design tokens
- show LayersPanel alongside component library in sidebar

## Testing
- `npm run lint` *(fails: `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688e661b7028832c8b9cde8f5abd82f3