### PR TITLE
fix: ensure properties panel respects toolbar offset

### DIFF
--- a/agentflow/src/components/DesignerLayout.tsx
+++ b/agentflow/src/components/DesignerLayout.tsx
@@ -54,8 +54,15 @@ export default function DesignerLayout({
   onTestFlow,
   testButtonDisabled = false,
 }: DesignerLayoutProps) {
+  const layoutStyle: React.CSSProperties = {
+    "--toolbar-height": "calc(var(--space-xl) + 48px)",
+  } as React.CSSProperties;
+
   return (
-    <div className="h-screen w-full flex overflow-hidden bg-[var(--figma-bg)]">
+    <div
+      className="h-screen w-full flex overflow-hidden bg-[var(--figma-bg)]"
+      style={layoutStyle}
+    >
       {/* Left Sidebar */}
       {left}
 

--- a/agentflow/src/components/PropertiesPanel.tsx
+++ b/agentflow/src/components/PropertiesPanel.tsx
@@ -52,7 +52,7 @@ export default function CompactPropertiesPanel({
     minWidth: "260px",
     maxWidth: "300px",
     // Offset the panel from the top toolbar and account for its height
-    height: "calc(100% - var(--toolbar-height, 5rem))",
+    height: "calc(100% - var(--toolbar-height))",
     minHeight: 0,
     display: "flex",
     flexDirection: "column",
@@ -66,7 +66,7 @@ export default function CompactPropertiesPanel({
     color: "#cccccc",
     position: "fixed", // Make it feel truly fixed
     right: 0,
-    top: "var(--toolbar-height, 5rem)",
+    top: "var(--toolbar-height)",
     zIndex: 100,
     boxSizing: "border-box",
   };


### PR DESCRIPTION
## Summary
- define `--toolbar-height` in DesignerLayout for consistent top-bar sizing
- offset PropertiesPanel using CSS variable for top and height

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in src/utils/typeGuards.ts, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688e6bed3618832cb03764d8cb63929e