### PR TITLE
refactor: sync properties panel state

### DIFF
--- a/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
@@ -1,6 +1,6 @@
 // All UI rules for properties panels must come from propertiesPanelTheme.ts
 // Enhanced Agent Properties Panel with VS Code styling
-import React from "react";
+import React, { useState } from "react";
 import {
   Bot,
   Settings,
@@ -49,7 +49,7 @@ export default function AgentPropertiesPanel({
   node,
   onChange,
 }: AgentPropertiesPanelProps) {
-  const data = node.data;
+  const [data, setData] = useState<AgentNodeData>(() => node.data);
 
   // Model options with descriptions
   const modelOptions = [
@@ -65,8 +65,11 @@ export default function AgentPropertiesPanel({
   ];
 
   const handleFieldChange = (field: keyof AgentNodeData, value: unknown) => {
-    const updatedData = { ...data, [field]: value };
-    onChange({ ...node, data: updatedData });
+    setData((prev) => {
+      const updatedData = { ...prev, [field]: value };
+      onChange({ ...node, data: { ...node.data, ...updatedData } });
+      return updatedData;
+    });
   };
 
   // Use theme-driven panel container style

--- a/agentflow/src/components/propertiesPanels/ChatInterfacePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/ChatInterfacePropertiesPanel.tsx
@@ -40,7 +40,12 @@ export default function ChatInterfacePropertiesPanel({
   );
 
   // Only update known fields, preserve extra fields
-  const handleFieldChange = (field: keyof ChatNodeData, value: unknown) => {
+  const handleFieldChange = <K extends keyof ChatNodeData>(
+    field: K,
+    value: ChatNodeData[K],
+    setter: (value: ChatNodeData[K]) => void
+  ) => {
+    setter(value);
     const updatedData = {
       ...node.data,
       [field]: value,
@@ -88,20 +93,18 @@ export default function ChatInterfacePropertiesPanel({
         <VSCodeInput
           style={inputStyle}
           value={title}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setTitle(e.target.value);
-            handleFieldChange("title", e.target.value);
-          }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            handleFieldChange("title", e.target.value, setTitle)
+          }
           placeholder="Chat title"
         />
         <label style={labelStyle}>Placeholder</label>
         <VSCodeInput
           style={inputStyle}
           value={placeholder}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setPlaceholder(e.target.value);
-            handleFieldChange("placeholder", e.target.value);
-          }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            handleFieldChange("placeholder", e.target.value, setPlaceholder)
+          }
           placeholder="Type your message..."
         />
         <div style={{ marginTop: theme.spacing.md }}>
@@ -109,10 +112,13 @@ export default function ChatInterfacePropertiesPanel({
             <input
               type="checkbox"
               checked={enableFileUpload}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setEnableFileUpload(e.target.checked);
-                handleFieldChange("enableFileUpload", e.target.checked);
-              }}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleFieldChange(
+                  "enableFileUpload",
+                  e.target.checked,
+                  setEnableFileUpload
+                )
+              }
               style={{ marginRight: theme.spacing.sm }}
             />
             Enable File Upload
@@ -123,10 +129,13 @@ export default function ChatInterfacePropertiesPanel({
             <input
               type="checkbox"
               checked={showHistory}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setShowHistory(e.target.checked);
-                handleFieldChange("showHistory", e.target.checked);
-              }}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleFieldChange(
+                  "showHistory",
+                  e.target.checked,
+                  setShowHistory
+                )
+              }
               style={{ marginRight: theme.spacing.sm }}
             />
             Show History

--- a/agentflow/src/components/propertiesPanels/ConversationFlowPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/ConversationFlowPropertiesPanel.tsx
@@ -23,7 +23,13 @@ interface TransitionInputProps {
   setTransitions: React.Dispatch<
     React.SetStateAction<{ from: string; to: string; condition: string }[]>
   >;
-  handleFieldChange: (field: string, value: unknown) => void;
+  handleFieldChange: (
+    field: string,
+    value: unknown,
+    setter: React.Dispatch<
+      React.SetStateAction<{ from: string; to: string; condition: string }[]>
+    >
+  ) => void;
 }
 
 const TransitionInput: React.FC<TransitionInputProps> = ({
@@ -47,8 +53,7 @@ const TransitionInput: React.FC<TransitionInputProps> = ({
         onChange={(e) => {
           const next = [...transitions];
           next[idx] = { ...next[idx], from: e.target.value };
-          setTransitions(next);
-          handleFieldChange("transitions", next);
+          handleFieldChange("transitions", next, setTransitions);
         }}
         placeholder="From"
         style={{ width: 90 }}
@@ -58,8 +63,7 @@ const TransitionInput: React.FC<TransitionInputProps> = ({
         onChange={(e) => {
           const next = [...transitions];
           next[idx] = { ...next[idx], to: e.target.value };
-          setTransitions(next);
-          handleFieldChange("transitions", next);
+          handleFieldChange("transitions", next, setTransitions);
         }}
         placeholder="To"
         style={{ width: 90 }}
@@ -69,8 +73,7 @@ const TransitionInput: React.FC<TransitionInputProps> = ({
         onChange={(e) => {
           const next = [...transitions];
           next[idx] = { ...next[idx], condition: e.target.value };
-          setTransitions(next);
-          handleFieldChange("transitions", next);
+          handleFieldChange("transitions", next, setTransitions);
         }}
         placeholder="Condition"
         style={{ width: 120 }}
@@ -80,8 +83,7 @@ const TransitionInput: React.FC<TransitionInputProps> = ({
         size="small"
         onClick={() => {
           const next = transitions.filter((_, i) => i !== idx);
-          setTransitions(next);
-          handleFieldChange("transitions", next);
+          handleFieldChange("transitions", next, setTransitions);
         }}
         style={{ marginLeft: theme.spacing.xs }}
       >
@@ -106,7 +108,12 @@ export default function ConversationFlowPropertiesPanel({
     { from: string; to: string; condition: string }[]
   >(() => node.data?.transitions || []);
 
-  const handleFieldChange = (field: string, value: unknown) => {
+  const handleFieldChange = <K extends keyof ConversationFlowNodeData>(
+    field: K,
+    value: ConversationFlowNodeData[K],
+    setter: (value: ConversationFlowNodeData[K]) => void
+  ) => {
+    setter(value);
     onChange({ ...node, data: { ...node.data, [field]: value } });
   };
 
@@ -133,8 +140,7 @@ export default function ConversationFlowPropertiesPanel({
               .split(",")
               .map((s) => s.trim())
               .filter(Boolean);
-            setStates(arr);
-            handleFieldChange("states", arr);
+            handleFieldChange("states", arr, setStates);
           }}
           placeholder="Comma separated states"
         />
@@ -145,10 +151,9 @@ export default function ConversationFlowPropertiesPanel({
       >
         <VSCodeInput
           value={initialState}
-          onChange={(e) => {
-            setInitialState(e.target.value);
-            handleFieldChange("initialState", e.target.value);
-          }}
+          onChange={(e) =>
+            handleFieldChange("initialState", e.target.value, setInitialState)
+          }
           placeholder="Initial state"
         />
       </PanelSection>
@@ -176,14 +181,13 @@ export default function ConversationFlowPropertiesPanel({
           <VSCodeButton
             variant="primary"
             size="small"
-            onClick={() => {
-              const next = [
-                ...transitions,
-                { from: "", to: "", condition: "" },
-              ];
-              setTransitions(next);
-              handleFieldChange("transitions", next);
-            }}
+            onClick={() =>
+              handleFieldChange(
+                "transitions",
+                [...transitions, { from: "", to: "", condition: "" }],
+                setTransitions
+              )
+            }
             style={{ marginTop: theme.spacing.xs }}
           >
             Add Transition
@@ -204,10 +208,9 @@ export default function ConversationFlowPropertiesPanel({
           <input
             type="checkbox"
             checked={persistState}
-            onChange={(e) => {
-              setPersistState(e.target.checked);
-              handleFieldChange("persistState", e.target.checked);
-            }}
+            onChange={(e) =>
+              handleFieldChange("persistState", e.target.checked, setPersistState)
+            }
             style={{ accentColor: theme.colors.textAccent }}
           />
           <span>Persist State</span>

--- a/agentflow/src/components/propertiesPanels/DashboardPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/DashboardPropertiesPanel.tsx
@@ -52,18 +52,19 @@ export default function DashboardPropertiesPanel({
   const [layout, setLayout] = useState<string>(safeData.layout);
 
   // Always update all fields to avoid partial updates
-  const handleFieldChange = (
-    field: keyof DashboardNodeData,
-    value: unknown
+  const handleFieldChange = <K extends keyof DashboardNodeData>(
+    field: K,
+    value: DashboardNodeData[K],
+    setter: (value: DashboardNodeData[K]) => void
   ) => {
-    let updated: DashboardNodeData = { widgets, title, layout };
-    if (field === "widgets" && Array.isArray(value)) {
-      updated = { ...updated, widgets: value as string[] };
-    } else if (field === "title" && typeof value === "string") {
-      updated = { ...updated, title: value };
-    } else if (field === "layout" && typeof value === "string") {
-      updated = { ...updated, layout: value };
-    }
+    setter(value);
+    const updated: DashboardNodeData = {
+      ...node.data,
+      widgets,
+      title,
+      layout,
+      [field]: value,
+    };
     setWidgets(updated.widgets);
     setTitle(updated.title);
     setLayout(updated.layout);
@@ -82,7 +83,7 @@ export default function DashboardPropertiesPanel({
         <VSCodeInput
           value={title}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            handleFieldChange("title", e.target.value)
+            handleFieldChange("title", e.target.value, setTitle)
           }
           placeholder="Dashboard title..."
         />
@@ -93,7 +94,7 @@ export default function DashboardPropertiesPanel({
       >
         <VSCodeSelect
           value={layout}
-          onValueChange={(v: string) => handleFieldChange("layout", v)}
+          onValueChange={(v: string) => handleFieldChange("layout", v, setLayout)}
           options={layoutOptions}
           placeholder="Choose layout"
         />
@@ -123,7 +124,7 @@ export default function DashboardPropertiesPanel({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const next = [...widgets];
                   next[idx] = e.target.value;
-                  handleFieldChange("widgets", next);
+                  handleFieldChange("widgets", next, setWidgets);
                 }}
                 style={{ width: 180 }}
               />
@@ -132,7 +133,7 @@ export default function DashboardPropertiesPanel({
                 size="small"
                 onClick={() => {
                   const next = widgets.filter((_, i) => i !== idx);
-                  handleFieldChange("widgets", next);
+                  handleFieldChange("widgets", next, setWidgets);
                 }}
               >
                 Remove
@@ -142,10 +143,9 @@ export default function DashboardPropertiesPanel({
           <VSCodeButton
             variant="primary"
             size="small"
-            onClick={() => {
-              const next = [...widgets, "newWidget"];
-              handleFieldChange("widgets", next);
-            }}
+            onClick={() =>
+              handleFieldChange("widgets", [...widgets, "newWidget"], setWidgets)
+            }
           >
             Add Widget
           </VSCodeButton>

--- a/agentflow/src/components/propertiesPanels/DecisionTreePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/DecisionTreePropertiesPanel.tsx
@@ -83,33 +83,51 @@ export default function DecisionTreePropertiesPanel({
     field: keyof DecisionTreeNodeData,
     value: unknown
   ) => {
-    if (field === "rules")
-      setRules(value as { condition: string; outputPath: string }[]);
-    if (field === "defaultPath") setDefaultPath(value as string);
-    if (field === "evaluationMode") setEvaluationMode(value as string);
-    if (field === "title") setTitle(value as string);
-    if (field === "description") setDescription(value as string);
-    if (field === "color") setColor(value as string);
-    if (field === "icon") setIcon(value as string);
-
     const updated: DecisionTreeNodeData = {
-      title: field === "title" ? (value as string) : title,
-      description: field === "description" ? (value as string) : description,
-      color: field === "color" ? (value as string) : color,
-      icon: field === "icon" ? (value as string) : icon,
+      ...node.data,
+      title,
+      description,
+      color,
+      icon,
       id: data.id,
       type: data.type,
       position: data.position,
       inputs: data.inputs,
       outputs: data.outputs,
-      rules:
-        field === "rules"
-          ? (value as { condition: string; outputPath: string }[])
-          : rules,
-      defaultPath: field === "defaultPath" ? (value as string) : defaultPath,
-      evaluationMode:
-        field === "evaluationMode" ? (value as string) : evaluationMode,
+      rules,
+      defaultPath,
+      evaluationMode,
     };
+
+    if (field === "rules") {
+      setRules(value as { condition: string; outputPath: string }[]);
+      updated.rules = value as { condition: string; outputPath: string }[];
+    }
+    if (field === "defaultPath") {
+      setDefaultPath(value as string);
+      updated.defaultPath = value as string;
+    }
+    if (field === "evaluationMode") {
+      setEvaluationMode(value as string);
+      updated.evaluationMode = value as string;
+    }
+    if (field === "title") {
+      setTitle(value as string);
+      updated.title = value as string;
+    }
+    if (field === "description") {
+      setDescription(value as string);
+      updated.description = value as string;
+    }
+    if (field === "color") {
+      setColor(value as string);
+      updated.color = value as string;
+    }
+    if (field === "icon") {
+      setIcon(value as string);
+      updated.icon = value as string;
+    }
+
     onChange({ ...node, data: updated });
   };
 

--- a/agentflow/src/components/propertiesPanels/IfElsePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/IfElsePropertiesPanel.tsx
@@ -1,5 +1,5 @@
 // If/Else Properties Panel with hardcoded minimal design
-import React from "react";
+import React, { useState } from "react";
 import { GitBranch } from "lucide-react";
 import { CanvasNode } from "@/types";
 import { PanelSection } from "./PanelSection";
@@ -38,18 +38,8 @@ export default function IfElsePropertiesPanel({
     return typeof data === "object" && data !== null && "condition" in data;
   }
 
-  const handleFieldChange = (field: keyof IfElseNodeData, value: unknown) => {
-    if (isIfElseNodeData(node.data)) {
-      const updatedData: IfElseNodeData = {
-        ...node.data,
-        [field]: value,
-      };
-      onChange({ ...node, data: updatedData });
-    }
-  };
-
-  // FIX: Correct ternary assignment for ifElseData
-  const ifElseData: IfElseNodeData = isIfElseNodeData(node.data)
+  // FIX: Correct ternary assignment for initialData
+  const initialData: IfElseNodeData = isIfElseNodeData(node.data)
     ? node.data
     : {
         condition: "",
@@ -63,6 +53,16 @@ export default function IfElsePropertiesPanel({
         history: [],
         state: {},
       };
+
+  const [data, setData] = useState<IfElseNodeData>(() => initialData);
+
+  const handleFieldChange = (field: keyof IfElseNodeData, value: unknown) => {
+    setData((prev) => {
+      const updatedData = { ...prev, [field]: value };
+      onChange({ ...node, data: { ...node.data, ...updatedData } });
+      return updatedData;
+    });
+  };
 
   return (
     <div
@@ -171,7 +171,7 @@ export default function IfElsePropertiesPanel({
             Boolean Expression
           </label>
           <input
-            value={ifElseData.condition || ""}
+            value={data.condition || ""}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               handleFieldChange("condition", e.target.value)
             }
@@ -230,7 +230,7 @@ export default function IfElsePropertiesPanel({
             Condition Message
           </label>
           <input
-            value={ifElseData.message || ""}
+            value={data.message || ""}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               handleFieldChange("message", e.target.value)
             }
@@ -289,7 +289,7 @@ export default function IfElsePropertiesPanel({
             Context Data
           </label>
           <textarea
-            value={JSON.stringify(ifElseData.context ?? {}, null, 2)}
+            value={JSON.stringify(data.context ?? {}, null, 2)}
             onChange={(e) => {
               try {
                 handleFieldChange("context", JSON.parse(e.target.value));
@@ -352,7 +352,7 @@ export default function IfElsePropertiesPanel({
             Execution History
           </label>
           <textarea
-            value={JSON.stringify(ifElseData.history ?? [], null, 2)}
+            value={JSON.stringify(data.history ?? [], null, 2)}
             readOnly
             rows={3}
             style={{
@@ -404,7 +404,7 @@ export default function IfElsePropertiesPanel({
             Node State
           </label>
           <textarea
-            value={JSON.stringify(ifElseData.state ?? {}, null, 2)}
+            value={JSON.stringify(data.state ?? {}, null, 2)}
             onChange={(e) => {
               try {
                 handleFieldChange("state", JSON.parse(e.target.value));
@@ -482,7 +482,7 @@ export default function IfElsePropertiesPanel({
             <div>
               <span style={{ color: "#f97316" }}>if</span> ({" "}
               <span style={{ color: "#38bdf8" }}>
-                {ifElseData.condition || "condition"}
+                {data.condition || "condition"}
               </span>{" "}
               ) {"{"}
               <br />

--- a/agentflow/src/components/propertiesPanels/SimulatorPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/SimulatorPropertiesPanel.tsx
@@ -27,7 +27,12 @@ export default function SimulatorPropertiesPanel({
     () => data.expectedOutput || ""
   );
 
-  const handleFieldChange = (field: string, value: unknown) => {
+  const handleFieldChange = (
+    field: string,
+    value: string,
+    setter: (value: string) => void
+  ) => {
+    setter(value);
     onChange({ ...node, data: { ...node.data, [field]: value } });
   };
 
@@ -72,10 +77,9 @@ export default function SimulatorPropertiesPanel({
         <textarea
           style={textareaStyle}
           value={testInput}
-          onChange={(e) => {
-            setTestInput(e.target.value);
-            handleFieldChange("testInput", e.target.value);
-          }}
+          onChange={(e) =>
+            handleFieldChange("testInput", e.target.value, setTestInput)
+          }
           placeholder="Input for simulation..."
         />
       </PanelSection>
@@ -86,10 +90,13 @@ export default function SimulatorPropertiesPanel({
         <textarea
           style={textareaStyle}
           value={expectedOutput}
-          onChange={(e) => {
-            setExpectedOutput(e.target.value);
-            handleFieldChange("expectedOutput", e.target.value);
-          }}
+          onChange={(e) =>
+            handleFieldChange(
+              "expectedOutput",
+              e.target.value,
+              setExpectedOutput
+            )
+          }
           placeholder="Expected output..."
         />
       </PanelSection>

--- a/agentflow/src/components/propertiesPanels/StateMachinePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/StateMachinePropertiesPanel.tsx
@@ -46,7 +46,12 @@ export default function StateMachinePropertiesPanel({
     { from: string; to: string; condition: string }[]
   >(() => (isStateMachineNodeData(node.data) ? node.data.transitions : []));
 
-  const handleFieldChange = (field: string, value: unknown) => {
+  const handleFieldChange = (
+    field: string,
+    value: unknown,
+    setter?: (value: any) => void
+  ) => {
+    if (setter) setter(value);
     onChange({ ...node, data: { ...node.data, [field]: value } });
   };
 
@@ -94,8 +99,7 @@ export default function StateMachinePropertiesPanel({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const next = [...states];
                   next[idx] = e.target.value;
-                  setStates(next);
-                  handleFieldChange("states", next);
+                  handleFieldChange("states", next, setStates);
                 }}
                 style={{ maxWidth: 160 }}
               />
@@ -104,8 +108,7 @@ export default function StateMachinePropertiesPanel({
                 size="small"
                 onClick={() => {
                   const next = states.filter((_, i) => i !== idx);
-                  setStates(next);
-                  handleFieldChange("states", next);
+                  handleFieldChange("states", next, setStates);
                 }}
               >
                 Remove
@@ -114,11 +117,9 @@ export default function StateMachinePropertiesPanel({
           ))}
           <VSCodeButton
             size="small"
-            onClick={() => {
-              const next = [...states, "newState"];
-              setStates(next);
-              handleFieldChange("states", next);
-            }}
+            onClick={() =>
+              handleFieldChange("states", [...states, "newState"], setStates)
+            }
           >
             Add State
           </VSCodeButton>
@@ -130,10 +131,9 @@ export default function StateMachinePropertiesPanel({
       >
         <VSCodeInput
           value={initialState}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setInitialState(e.target.value);
-            handleFieldChange("initialState", e.target.value);
-          }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            handleFieldChange("initialState", e.target.value, setInitialState)
+          }
           style={{ maxWidth: 160 }}
         />
       </PanelSection>
@@ -162,8 +162,7 @@ export default function StateMachinePropertiesPanel({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const next = [...transitions];
                   next[idx] = { ...next[idx], from: e.target.value };
-                  setTransitions(next);
-                  handleFieldChange("transitions", next);
+                  handleFieldChange("transitions", next, setTransitions);
                 }}
                 style={{ maxWidth: 100 }}
                 placeholder="From"
@@ -173,8 +172,7 @@ export default function StateMachinePropertiesPanel({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const next = [...transitions];
                   next[idx] = { ...next[idx], to: e.target.value };
-                  setTransitions(next);
-                  handleFieldChange("transitions", next);
+                  handleFieldChange("transitions", next, setTransitions);
                 }}
                 style={{ maxWidth: 100 }}
                 placeholder="To"
@@ -184,8 +182,7 @@ export default function StateMachinePropertiesPanel({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const next = [...transitions];
                   next[idx] = { ...next[idx], condition: e.target.value };
-                  setTransitions(next);
-                  handleFieldChange("transitions", next);
+                  handleFieldChange("transitions", next, setTransitions);
                 }}
                 style={{ maxWidth: 160 }}
                 placeholder="Condition"
@@ -195,8 +192,7 @@ export default function StateMachinePropertiesPanel({
                 size="small"
                 onClick={() => {
                   const next = transitions.filter((_, i) => i !== idx);
-                  setTransitions(next);
-                  handleFieldChange("transitions", next);
+                  handleFieldChange("transitions", next, setTransitions);
                 }}
               >
                 Remove

--- a/agentflow/src/components/propertiesPanels/TestCasePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/TestCasePropertiesPanel.tsx
@@ -55,9 +55,14 @@ export default function TestCasePropertiesPanel({
     () => testCaseData.assertType || assertTypes[0].value
   );
 
-  function handleFieldChange(field: keyof TestCaseNodeData, value: string) {
+  function handleFieldChange(
+    field: keyof TestCaseNodeData,
+    value: string,
+    setter: (value: string) => void
+  ) {
+    setter(value);
     const updatedData: TestCaseNodeData = {
-      ...testCaseData,
+      ...node.data,
       [field]: value,
     };
     onChange({ ...node, data: updatedData });
@@ -103,10 +108,9 @@ export default function TestCasePropertiesPanel({
       >
         <VSCodeInput
           value={description}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setDescription(e.target.value);
-            handleFieldChange("description", e.target.value);
-          }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            handleFieldChange("description", e.target.value, setDescription)
+          }
           placeholder="Test case description..."
           style={{
             width: "100%",
@@ -125,10 +129,9 @@ export default function TestCasePropertiesPanel({
         <textarea
           style={textareaStyle}
           value={input}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            setInput(e.target.value);
-            handleFieldChange("input", e.target.value);
-          }}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            handleFieldChange("input", e.target.value, setInput)
+          }
           placeholder="Test input..."
         />
       </PanelSection>
@@ -139,10 +142,13 @@ export default function TestCasePropertiesPanel({
         <textarea
           style={textareaStyle}
           value={expectedOutput}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            setExpectedOutput(e.target.value);
-            handleFieldChange("expectedOutput", e.target.value);
-          }}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            handleFieldChange(
+              "expectedOutput",
+              e.target.value,
+              setExpectedOutput
+            )
+          }
           placeholder="Expected output..."
         />
       </PanelSection>
@@ -152,10 +158,9 @@ export default function TestCasePropertiesPanel({
       >
         <VSCodeSelect
           value={assertType}
-          onValueChange={(v: string) => {
-            setAssertType(v);
-            handleFieldChange("assertType", v);
-          }}
+          onValueChange={(v: string) =>
+            handleFieldChange("assertType", v, setAssertType)
+          }
           options={assertTypes}
           placeholder="Choose assertion type"
           style={{


### PR DESCRIPTION
## Summary
- initialize properties panel state from `node.data`
- update `handleFieldChange` to sync local state and call `onChange`
- preserve existing data fields when updating nodes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbfb4b0d8832c860632f868929231