### PR TITLE
feat: add VSCode form widgets and conditional panel logic

### DIFF
--- a/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
@@ -20,6 +20,8 @@ import {
   VSCodeInput,
   VSCodeSelect,
   VSCodeButton,
+  VSCodeSlider,
+  VSCodeTagInput,
 } from "./vsCodeFormComponents";
 
 interface AgentNodeData {
@@ -50,6 +52,9 @@ export default function AgentPropertiesPanel({
   onChange,
 }: AgentPropertiesPanelProps) {
   const data = node.data;
+  const personalityTags = Array.isArray(data?.personalityTags)
+    ? data.personalityTags
+    : [];
 
   // Model options with descriptions
   const modelOptions = [
@@ -197,10 +202,41 @@ export default function AgentPropertiesPanel({
             options={modelOptions}
             onValueChange={(value: string) => handleFieldChange("model", value)}
           />
+          <label
+            style={{
+              color: "#b3b3b3",
+              fontSize: 14,
+              marginTop: 8,
+              marginBottom: 4,
+            }}
+          >
+            Temperature
+          </label>
+          <VSCodeSlider
+            value={data?.temperature ?? 0.7}
+            min={0}
+            max={1}
+            step={0.01}
+            onValueChange={(v) => handleFieldChange("temperature", v)}
+          />
 
-          {/* TODO: VSCodeSlider not implemented. Insert slider for Temperature here. */}
-
-          {/* TODO: VSCodeSlider not implemented. Insert slider for Max Tokens here. */}
+          <label
+            style={{
+              color: "#b3b3b3",
+              fontSize: 14,
+              marginTop: 8,
+              marginBottom: 4,
+            }}
+          >
+            Max Tokens
+          </label>
+          <VSCodeSlider
+            value={data?.maxTokens ?? 1000}
+            min={1}
+            max={8000}
+            step={1}
+            onValueChange={(v) => handleFieldChange("maxTokens", v)}
+          />
 
           <label
             style={{
@@ -237,7 +273,10 @@ export default function AgentPropertiesPanel({
           >
             Personality Tags
           </label>
-          {/* TODO: VSCodeTagInput not implemented. Insert tag input for Personality Tags here. */}
+          <VSCodeTagInput
+            tags={personalityTags}
+            onChange={(tags) => handleFieldChange("personalityTags", tags)}
+          />
 
           <label
             style={{
@@ -266,10 +305,69 @@ export default function AgentPropertiesPanel({
           icon={<Zap size={16} />}
           defaultCollapsed={true}
         >
-          {/* TODO: VSCodeSlider not implemented. Insert slider for Confidence Threshold here. */}
-          {/* TODO: VSCodeToggle not implemented. Insert toggle for Function Calling here. */}
-          {/* TODO: VSCodeSlider not implemented. Insert slider for Context Window here. */}
-          <div />
+          <label
+            style={{
+              color: "#b3b3b3",
+              fontSize: 14,
+              marginBottom: 4,
+            }}
+          >
+            Enable Function Calling
+          </label>
+          <input
+            type="checkbox"
+            checked={!!data?.enableFunctionCalling}
+            onChange={(e) =>
+              handleFieldChange("enableFunctionCalling", e.target.checked)
+            }
+            style={{
+              accentColor: theme.colors.info,
+              width: 16,
+              height: 16,
+              borderRadius: theme.borderRadius.md,
+              border: `1px solid ${theme.colors.border}`,
+              marginBottom: theme.spacing.md,
+            }}
+          />
+          {data?.enableFunctionCalling && (
+            <>
+              <label
+                style={{
+                  color: "#b3b3b3",
+                  fontSize: 14,
+                  marginBottom: 4,
+                }}
+              >
+                Confidence Threshold
+              </label>
+              <VSCodeSlider
+                value={data?.confidenceThreshold ?? 0.5}
+                min={0}
+                max={1}
+                step={0.01}
+                onValueChange={(v) =>
+                  handleFieldChange("confidenceThreshold", v)
+                }
+              />
+              <label
+                style={{
+                  color: "#b3b3b3",
+                  fontSize: 14,
+                  marginTop: 8,
+                  marginBottom: 4,
+                }}
+              >
+                Context Window
+              </label>
+              <VSCodeSlider
+                value={data?.contextWindow ?? 1000}
+                min={0}
+                max={8000}
+                step={50}
+                onValueChange={(v) => handleFieldChange("contextWindow", v)}
+              />
+            </>
+          )}
         </PanelSection>
 
         {/* Escalation Logic */}
@@ -279,26 +377,45 @@ export default function AgentPropertiesPanel({
           icon={<AlertTriangle size={16} />}
           defaultCollapsed={true}
         >
-          {/* TODO: VSCodeSlider not implemented. Insert slider for Escalation Threshold here. */}
-
           <label
             style={{
-              color: "#111111",
+              color: "#b3b3b3",
               fontSize: 14,
-              marginTop: 8,
               marginBottom: 4,
             }}
           >
-            Escalation Message
+            Escalation Threshold
           </label>
-          <VSCodeInput
-            placeholder="Let me connect you with a human specialist..."
-            value={data?.escalationMessage ?? ""}
-            onChange={(
-              e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-            ) => handleFieldChange("escalationMessage", e.target.value)}
-            type="textarea"
+          <VSCodeSlider
+            value={data?.escalationThreshold ?? 0}
+            min={0}
+            max={1}
+            step={0.01}
+            onValueChange={(v) => handleFieldChange("escalationThreshold", v)}
           />
+
+          {((data?.escalationThreshold ?? 0) > 0) && (
+            <>
+              <label
+                style={{
+                  color: "#b3b3b3",
+                  fontSize: 14,
+                  marginTop: 8,
+                  marginBottom: 4,
+                }}
+              >
+                Escalation Message
+              </label>
+              <VSCodeInput
+                placeholder="Let me connect you with a human specialist..."
+                value={data?.escalationMessage ?? ""}
+                onChange={(
+                  e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+                ) => handleFieldChange("escalationMessage", e.target.value)}
+                type="textarea"
+              />
+            </>
+          )}
         </PanelSection>
 
         {/* Testing & Preview */}

--- a/agentflow/src/components/propertiesPanels/DecisionTreePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/DecisionTreePropertiesPanel.tsx
@@ -7,6 +7,7 @@ import {
   VSCodeInput,
   VSCodeSelect,
   VSCodeButton,
+  VSCodeColorPicker,
 } from "./vsCodeFormComponents";
 
 interface DecisionTreeNodeData {
@@ -166,12 +167,9 @@ export default function DecisionTreePropertiesPanel({
         />
       </PanelSection>
       <PanelSection title="Color" description="Set a color for this node.">
-        <VSCodeInput
+        <VSCodeColorPicker
           value={color}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            handleFieldChange("color", e.target.value)
-          }
-          placeholder="#4B5563"
+          onChange={(v: string) => handleFieldChange("color", v)}
         />
       </PanelSection>
       <PanelSection title="Icon" description="Set an icon for this node.">

--- a/agentflow/src/components/propertiesPanels/KnowledgeBasePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/KnowledgeBasePropertiesPanel.tsx
@@ -147,38 +147,40 @@ export default function KnowledgeBasePropertiesPanel({
           placeholder="Select operation"
         />
       </PanelSection>
-      <PanelSection title="Documents" description="JSON array of documents">
-        <VSCodeInput
-          style={{
-            minHeight: 48,
-            fontFamily: theme.typography.fontMono,
-            fontSize: theme.typography.fontSize.base,
-            background: theme.colors.backgroundTertiary,
-            color: theme.colors.textPrimary,
-            border: `1px solid ${theme.colors.border}`,
-            borderRadius: theme.borderRadius.sm,
-            padding: theme.spacing.inputPadding,
-            resize: "vertical",
-            width: "100%",
-            boxSizing: "border-box",
-          }}
-          value={documents}
-          onChange={(
-            e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-          ) => {
-            setDocuments(e.target.value);
-            try {
-              handleFieldChange("documents", JSON.parse(e.target.value));
-            } catch {}
-          }}
-          placeholder={`[
+      {operation === "store" && (
+        <PanelSection title="Documents" description="JSON array of documents">
+          <VSCodeInput
+            style={{
+              minHeight: 48,
+              fontFamily: theme.typography.fontMono,
+              fontSize: theme.typography.fontSize.base,
+              background: theme.colors.backgroundTertiary,
+              color: theme.colors.textPrimary,
+              border: `1px solid ${theme.colors.border}`,
+              borderRadius: theme.borderRadius.sm,
+              padding: theme.spacing.inputPadding,
+              resize: "vertical",
+              width: "100%",
+              boxSizing: "border-box",
+            }}
+            value={documents}
+            onChange={(
+              e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+            ) => {
+              setDocuments(e.target.value);
+              try {
+                handleFieldChange("documents", JSON.parse(e.target.value));
+              } catch {}
+            }}
+            placeholder={`[
   {
     "title": "Document 1",
     "content": "..."
   }
 ]`}
-        />
-      </PanelSection>
+          />
+        </PanelSection>
+      )}
       <PanelSection title="Metadata" description="Additional metadata as JSON">
         <VSCodeInput
           style={{

--- a/agentflow/src/components/propertiesPanels/vsCodeFormComponents.tsx
+++ b/agentflow/src/components/propertiesPanels/vsCodeFormComponents.tsx
@@ -135,3 +135,172 @@ export const VSCodeButton: React.FC<VSCodeButtonProps> = ({
     />
   );
 };
+
+// VSCodeSlider
+interface VSCodeSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onValueChange: (v: number) => void;
+  style?: React.CSSProperties;
+}
+export const VSCodeSlider: React.FC<VSCodeSliderProps> = ({
+  value,
+  min,
+  max,
+  step = 1,
+  onValueChange,
+  style,
+}) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing.sm,
+      width: "100%",
+      ...style,
+    }}
+  >
+    <input
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={(e) => onValueChange(Number(e.target.value))}
+      style={{ flex: 1 }}
+    />
+    <span
+      style={{
+        width: 48,
+        textAlign: "right",
+        fontFamily: "Menlo, monospace",
+        fontSize: "13px",
+        color: theme.colors.textPrimary,
+      }}
+    >
+      {value}
+    </span>
+  </div>
+);
+
+// VSCodeTagInput
+interface VSCodeTagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+  style?: React.CSSProperties;
+}
+export const VSCodeTagInput: React.FC<VSCodeTagInputProps> = ({
+  tags,
+  onChange,
+  placeholder = "Add tag",
+  style,
+}) => {
+  const [input, setInput] = React.useState("");
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && input.trim()) {
+      e.preventDefault();
+      if (!tags.includes(input.trim())) {
+        onChange([...tags, input.trim()]);
+      }
+      setInput("");
+    }
+  };
+
+  const removeTag = (idx: number) => {
+    const next = [...tags];
+    next.splice(idx, 1);
+    onChange(next);
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: theme.spacing.xs,
+        background: theme.colors.backgroundSecondary,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: "6px",
+        padding: theme.spacing.xs,
+        ...style,
+      }}
+    >
+      {tags.map((tag, i) => (
+        <span
+          key={tag + i}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            background: theme.colors.backgroundTertiary,
+            padding: "2px 6px",
+            borderRadius: "4px",
+            fontSize: 13,
+            fontFamily: "Menlo, monospace",
+            color: theme.colors.textPrimary,
+          }}
+        >
+          {tag}
+          <button
+            onClick={() => removeTag(i)}
+            style={{
+              background: "none",
+              border: "none",
+              color: theme.colors.textSecondary,
+              cursor: "pointer",
+            }}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        style={{
+          flex: 1,
+          minWidth: 60,
+          background: "transparent",
+          border: "none",
+          color: theme.colors.textPrimary,
+          fontFamily: "Menlo, monospace",
+          fontSize: "13px",
+          outline: "none",
+        }}
+      />
+    </div>
+  );
+};
+
+// VSCodeColorPicker
+interface VSCodeColorPickerProps {
+  value: string;
+  onChange: (v: string) => void;
+  style?: React.CSSProperties;
+}
+export const VSCodeColorPicker: React.FC<VSCodeColorPickerProps> = ({
+  value,
+  onChange,
+  style,
+}) => (
+  <input
+    type="color"
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    style={{
+      width: "100%",
+      height: 32,
+      background: theme.colors.backgroundSecondary,
+      border: `1px solid ${theme.colors.border}`,
+      borderRadius: "6px",
+      padding: 0,
+      ...style,
+    }}
+  />
+);


### PR DESCRIPTION
## Summary
- add VSCode-style slider, tag input, and color picker components
- wire agent panel sliders and tag editor with conditional sections
- enable color selection and conditional fields in knowledge base and decision tree panels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbfbc6afc832ca76e3682e20e7e08