### PR TITLE
feat: enhance node visuals with gradients and accents

### DIFF
--- a/agentflow/src/components/ConversationFlowNode.tsx
+++ b/agentflow/src/components/ConversationFlowNode.tsx
@@ -1,10 +1,20 @@
-import React, { useState, useEffect } from 'react';
-import { MessageSquare, Plus, GitBranch, Trash2, Edit2, ChevronRight, User, Bot } from 'lucide-react';
+import React, { useState, useEffect } from "react";
+import {
+  MessageSquare,
+  Plus,
+  GitBranch,
+  Trash2,
+  Edit2,
+  ChevronRight,
+  User,
+  Bot,
+} from "lucide-react";
 import {
   figmaNodeStyle,
   selectedNodeStyle,
-  hoverNodeStyle
-} from './nodeStyles';
+  hoverNodeStyle,
+} from "./nodeStyles";
+import { nodeCategories } from "@/data/nodeDefinitions";
 
 interface ConversationNodeData {
   messages: ConversationMessage[];
@@ -161,17 +171,23 @@ export default function ConversationFlowNode({
   // - Use subtle hover/focus effects
   // - Use monospace font for message bubbles for a professional feel
 
-  const nodeStyle: React.CSSProperties = {
+  const nodeDef = nodeCategories
+    .flatMap((c) => c.nodes)
+    .find((n) => n.id === "conversation-flow");
+  const accentColor = nodeDef?.color || "var(--figma-accent)";
+
+  const nodeStyle: React.CSSProperties & { "--node-accent"?: string } = {
     ...figmaNodeStyle,
     left: node.position.x,
     top: node.position.y,
     width: 400,
     minHeight: 300,
-    borderColor: isSelected ? 'var(--figma-accent)' : 'var(--figma-border)',
+    borderWidth: 2,
+    "--node-accent": accentColor,
     zIndex: isSelected ? 10 : 5,
     fontFamily: 'Inter, Menlo, monospace',
     ...(isHovered ? hoverNodeStyle : {}),
-    ...(isSelected ? selectedNodeStyle : {})
+    ...(isSelected ? selectedNodeStyle : {}),
   };
 
   return (
@@ -184,10 +200,15 @@ export default function ConversationFlowNode({
       onMouseLeave={() => setIsHovered(false)}
     >
       {/* Header */}
-      <div className="bg-[#23232a] px-3 py-2 flex items-center justify-between border-b border-[#23232a]">
+      <div
+        className="px-3 py-2 flex items-center justify-between border-b"
+        style={{ backgroundColor: "#23232a", borderColor: accentColor }}
+      >
         <div className="flex items-center gap-2">
-          <MessageSquare className="w-5 h-5 text-blue-500" />
-          <span className="font-medium text-white text-sm tracking-tight">Conversation Flow</span>
+          <MessageSquare className="w-5 h-5" style={{ color: accentColor }} />
+          <span className="font-medium text-white text-sm tracking-tight">
+            Conversation Flow
+          </span>
         </div>
         <div className="flex gap-1">
           <button

--- a/agentflow/src/components/nodeStyles.ts
+++ b/agentflow/src/components/nodeStyles.ts
@@ -1,14 +1,29 @@
-import type { CSSProperties } from 'react';
-import { figmaHoverStyle, figmaSelectedStyle } from '../utils/figmaInteractions';
+import type { CSSProperties } from "react";
+import { figmaHoverStyle, figmaSelectedStyle } from "../utils/figmaInteractions";
 
+// Base style shared by all nodes
 export const figmaNodeStyle: CSSProperties = {
-  backgroundColor: 'var(--figma-surface)',
-  border: '1px solid var(--figma-border)',
-  borderRadius: 'var(--figma-radius)',
-  boxShadow: '0 2px 8px #000a',
-  transition: 'box-shadow 0.2s ease'
+  backgroundImage:
+    "linear-gradient(135deg, var(--figma-surface) 0%, var(--figma-surface-hover) 100%)",
+  border: "1px solid var(--node-accent, var(--figma-border))",
+  borderRadius: "var(--figma-radius)",
+  boxShadow:
+    "0 1px 3px rgba(0,0,0,0.3), 0 4px 6px rgba(0,0,0,0.2)",
+  transition: "transform 0.2s ease, box-shadow 0.2s ease",
 };
 
-export const selectedNodeStyle: CSSProperties = figmaSelectedStyle;
+// Hover and selection enhancements build on the base style but allow
+// customization through the --node-accent CSS variable.
+export const hoverNodeStyle: CSSProperties = {
+  ...figmaHoverStyle,
+  transform: "scale(1.02)",
+  boxShadow:
+    "0 0 0 2px var(--node-accent, var(--figma-border)), 0 4px 12px rgba(0,0,0,0.3)",
+};
 
-export const hoverNodeStyle: CSSProperties = figmaHoverStyle;
+export const selectedNodeStyle: CSSProperties = {
+  ...figmaSelectedStyle,
+  transform: "scale(1.03)",
+  boxShadow:
+    "0 0 0 2px var(--node-accent, var(--figma-accent)), 0 6px 16px rgba(0,0,0,0.4), 0 0 8px var(--node-accent, var(--figma-accent))",
+};


### PR DESCRIPTION
## Summary
- apply gradient backgrounds and layered shadows for a richer node appearance
- add hover/selection animations and per-type accent borders and icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbfbdb9e4832c9d4f4d748025befa