### PR TITLE
refactor: add node data type guards

### DIFF
--- a/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
@@ -10,7 +10,8 @@ import {
   Info,
   MessageSquare,
 } from "lucide-react";
-import { CanvasNode } from "@/types";
+import { CanvasNode, AgentNodeData as BaseAgentNodeData } from "@/types";
+import { isAgentNodeData } from "@/utils/typeGuards";
 import {
   figmaPropertiesTheme as theme,
   getPanelContainerStyle,
@@ -22,34 +23,37 @@ import {
   VSCodeButton,
 } from "./vsCodeFormComponents";
 
-interface AgentNodeData {
+type AgentNodeData = BaseAgentNodeData & {
   name?: string;
   role?: string;
-  personality?: string;
-  systemPrompt?: string;
   escalationThreshold?: number;
   escalationMessage?: string;
-  model?: string;
-  temperature?: number;
-  maxTokens?: number;
   responseFormat?: string;
   personalityTags?: string[];
   enableFunctionCalling?: boolean;
-  confidenceThreshold?: number;
   contextWindow?: number;
-  [key: string]: unknown;
-}
+};
 
 interface AgentPropertiesPanelProps {
-  node: CanvasNode & { data: AgentNodeData };
-  onChange: (node: CanvasNode & { data: AgentNodeData }) => void;
+  node: CanvasNode;
+  onChange: (node: CanvasNode) => void;
 }
 
 export default function AgentPropertiesPanel({
   node,
   onChange,
 }: AgentPropertiesPanelProps) {
-  const data = node.data;
+  const defaultData: AgentNodeData = {
+    title: "Unnamed Agent",
+    description: "",
+    color: "",
+    icon: "",
+    model: "gemini-pro",
+    temperature: 0.7,
+  };
+  const data: AgentNodeData = isAgentNodeData(node.data)
+    ? { ...defaultData, ...(node.data as AgentNodeData) }
+    : defaultData;
 
   // Model options with descriptions
   const modelOptions = [
@@ -65,7 +69,10 @@ export default function AgentPropertiesPanel({
   ];
 
   const handleFieldChange = (field: keyof AgentNodeData, value: unknown) => {
-    const updatedData = { ...data, [field]: value };
+    const current: AgentNodeData = isAgentNodeData(node.data)
+      ? (node.data as AgentNodeData)
+      : defaultData;
+    const updatedData = { ...current, [field]: value };
     onChange({ ...node, data: updatedData });
   };
 

--- a/agentflow/src/components/propertiesPanels/SimulatorPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/SimulatorPropertiesPanel.tsx
@@ -2,7 +2,8 @@
 import React, { useState } from "react";
 import { figmaPropertiesTheme as theme } from "./propertiesPanelTheme";
 import { VSCodeButton } from "./vsCodeFormComponents";
-import { CanvasNode } from "@/types";
+import { CanvasNode, SimulatorNodeData } from "@/types";
+import { isSimulatorNodeData } from "@/utils/typeGuards";
 import { PanelSection } from "./PanelSection";
 
 interface SimulatorPropertiesPanelProps {
@@ -14,21 +15,24 @@ export default function SimulatorPropertiesPanel({
   node,
   onChange,
 }: SimulatorPropertiesPanelProps) {
-  // Use type assertion to allow testInput/expectedOutput as optional fields
-  const data = node.data as typeof node.data & {
-    testInput?: string;
-    expectedOutput?: string;
-  };
+  const defaultData: SimulatorNodeData = { testInput: "", expectedOutput: "" };
+  const data: SimulatorNodeData = isSimulatorNodeData(node.data)
+    ? { ...defaultData, ...(node.data as SimulatorNodeData) }
+    : defaultData;
 
-  const [testInput, setTestInput] = useState<string>(
-    () => data.testInput || ""
-  );
+  const [testInput, setTestInput] = useState<string>(data.testInput || "");
   const [expectedOutput, setExpectedOutput] = useState<string>(
-    () => data.expectedOutput || ""
+    data.expectedOutput || "",
   );
 
-  const handleFieldChange = (field: string, value: unknown) => {
-    onChange({ ...node, data: { ...node.data, [field]: value } });
+  const handleFieldChange = (
+    field: keyof SimulatorNodeData,
+    value: unknown,
+  ) => {
+    const current: SimulatorNodeData = isSimulatorNodeData(node.data)
+      ? (node.data as SimulatorNodeData)
+      : defaultData;
+    onChange({ ...node, data: { ...current, [field]: value } });
   };
 
   // Compose panel style from theme

--- a/agentflow/src/utils/typeGuards.ts
+++ b/agentflow/src/utils/typeGuards.ts
@@ -10,7 +10,10 @@ import type {
   ConversationFlowNodeData,
   SimulatorNodeData,
   DashboardNodeData,
-  ChatNodeData
+  ChatNodeData,
+  AgentNodeData,
+  ToolAgentNodeData,
+  ComplexIfElseNodeData
 } from "@/types";
 
 export function isMessageNodeData(data: unknown): data is MessageNodeData {
@@ -108,5 +111,35 @@ export function isChatNodeData(data: unknown): data is ChatNodeData {
     typeof data === "object" &&
     data !== null &&
     ("messages" in data && Array.isArray((data as Record<string, unknown>).messages))
+  );
+}
+
+export function isAgentNodeData(data: unknown): data is AgentNodeData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    ("model" in (data as Record<string, unknown>) ||
+      "systemPrompt" in (data as Record<string, unknown>) ||
+      "title" in (data as Record<string, unknown>))
+  );
+}
+
+export function isToolAgentNodeData(
+  data: unknown
+): data is ToolAgentNodeData {
+  return (
+    isAgentNodeData(data) &&
+    typeof (data as Record<string, unknown>).toolConfig === "object"
+  );
+}
+
+export function isComplexIfElseNodeData(
+  data: unknown
+): data is ComplexIfElseNodeData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    Array.isArray((data as Record<string, unknown>).conditionGroups) &&
+    typeof (data as Record<string, unknown>).globalOperator === "string"
   );
 }


### PR DESCRIPTION
## Summary
- extend `typeGuards` with `isAgentNodeData`, `isToolAgentNodeData`, and `isComplexIfElseNodeData`
- guard node panels with safe access and defaults for malformed data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbfb65c4c832ca7deb4e3b5f20c52