### PR TITLE
feat: enhance panel sections with sticky headers

### DIFF
--- a/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
@@ -78,6 +78,9 @@ export default function AgentPropertiesPanel({
     display: "flex",
     alignItems: "center",
     gap: theme.spacing.md,
+    position: "sticky",
+    top: 0,
+    zIndex: 2,
   };
   const headerTitleStyle: React.CSSProperties = {
     fontSize: theme.typography.fontSize.md,
@@ -266,8 +269,16 @@ export default function AgentPropertiesPanel({
           icon={<Zap size={16} />}
           defaultCollapsed={true}
         >
+          <PanelSection
+            title="Function Calling"
+            description="Enable or disable function call support"
+            level={2}
+            defaultCollapsed={true}
+            icon={<Settings size={16} />}
+          >
+            {/* TODO: VSCodeToggle not implemented. Insert toggle for Function Calling here. */}
+          </PanelSection>
           {/* TODO: VSCodeSlider not implemented. Insert slider for Confidence Threshold here. */}
-          {/* TODO: VSCodeToggle not implemented. Insert toggle for Function Calling here. */}
           {/* TODO: VSCodeSlider not implemented. Insert slider for Context Window here. */}
           <div />
         </PanelSection>

--- a/agentflow/src/components/propertiesPanels/KnowledgeBasePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/KnowledgeBasePropertiesPanel.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { VSCodeSelect, VSCodeInput } from "./vsCodeFormComponents";
 import { figmaPropertiesTheme as theme } from "./propertiesPanelTheme";
 import { CanvasNode } from "@/types";
+import { Database, FileText, Info } from "lucide-react";
 
 import { PanelSection } from "./PanelSection";
 
@@ -134,7 +135,11 @@ export default function KnowledgeBasePropertiesPanel({
         overflowX: "hidden",
       }}
     >
-      <PanelSection title="Operation" description="Choose what this node does">
+      <PanelSection
+        title="Operation"
+        description="Choose what this node does"
+        icon={<Database size={16} />}
+      >
         <VSCodeSelect
           value={operation}
           onValueChange={(val: string) =>
@@ -147,7 +152,11 @@ export default function KnowledgeBasePropertiesPanel({
           placeholder="Select operation"
         />
       </PanelSection>
-      <PanelSection title="Documents" description="JSON array of documents">
+      <PanelSection
+        title="Documents"
+        description="JSON array of documents"
+        icon={<FileText size={16} />}
+      >
         <VSCodeInput
           style={{
             minHeight: 48,
@@ -179,7 +188,11 @@ export default function KnowledgeBasePropertiesPanel({
 ]`}
         />
       </PanelSection>
-      <PanelSection title="Metadata" description="Additional metadata as JSON">
+      <PanelSection
+        title="Metadata"
+        description="Additional metadata as JSON"
+        icon={<Info size={16} />}
+      >
         <VSCodeInput
           style={{
             minHeight: 48,

--- a/agentflow/src/components/propertiesPanels/PanelSection.tsx
+++ b/agentflow/src/components/propertiesPanels/PanelSection.tsx
@@ -14,6 +14,8 @@ interface PanelSectionProps {
   level?: 1 | 2 | 3; // For nested sections
   icon?: React.ReactNode;
   actions?: React.ReactNode; // For section-level actions
+  sticky?: boolean; // Make header stick to top of scroll container
+  stickyOffset?: number; // Optional offset for sticky headers
 }
 
 export const PanelSection: React.FC<PanelSectionProps> = ({
@@ -25,9 +27,15 @@ export const PanelSection: React.FC<PanelSectionProps> = ({
   level = 1,
   icon,
   actions,
+  sticky = false,
+  stickyOffset = 0,
 }) => {
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const [isHovered, setIsHovered] = useState(false);
+
+  // Calculate left padding based on nesting level
+  const basePadding = parseInt(theme.spacing.lg);
+  const leftPadding = `${basePadding * level}px`;
 
   // ===== CONSISTENT SECTION STYLING =====
   const sectionStyle: React.CSSProperties = {
@@ -49,10 +57,11 @@ export const PanelSection: React.FC<PanelSectionProps> = ({
 
   const headerStyle: React.CSSProperties = {
     height: theme.components.section.headerHeight,
-    background: "none",
+    background: sticky ? theme.colors.backgroundSecondary : "none",
     border: "none",
     borderBottom: "none",
-    padding: `0 ${theme.spacing.lg}`,
+    paddingRight: theme.spacing.lg,
+    paddingLeft: leftPadding,
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
@@ -61,6 +70,11 @@ export const PanelSection: React.FC<PanelSectionProps> = ({
     width: "100%",
     textAlign: "left",
     boxShadow: "none",
+    ...(sticky && {
+      position: "sticky",
+      top: stickyOffset,
+      zIndex: 1,
+    }),
   };
 
   const headerContentStyle: React.CSSProperties = {
@@ -136,7 +150,8 @@ export const PanelSection: React.FC<PanelSectionProps> = ({
     overflowX: "hidden",
     overflowY: "visible",
     transition: `max-height ${theme.animation.medium}, padding ${theme.animation.medium}`,
-    padding: collapsed ? "0" : `0 20px`,
+    paddingRight: collapsed ? "0" : theme.spacing.lg,
+    paddingLeft: collapsed ? "0" : leftPadding,
     boxSizing: "border-box",
     width: "100%",
     minWidth: 0,
@@ -144,8 +159,8 @@ export const PanelSection: React.FC<PanelSectionProps> = ({
   };
 
   const contentInnerStyle: React.CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
     gap: theme.spacing.fieldGap,
     opacity: collapsed ? 0 : 1,
     transition: `opacity ${theme.animation.medium}`,


### PR DESCRIPTION
## Summary
- add sticky header and responsive grid support to PanelSection
- make AgentPropertiesPanel header sticky and show nested function section
- display icons on KnowledgeBasePropertiesPanel sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688fbfb99350832c8fddc8b01865db21