### PR TITLE
Annotate change events and add inline error handling

### DIFF
--- a/agentflow/src/components/propertiesPanels/ConversationFlowPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/ConversationFlowPropertiesPanel.tsx
@@ -44,7 +44,7 @@ const TransitionInput: React.FC<TransitionInputProps> = ({
     >
       <VSCodeInput
         value={tr.from || ""}
-        onChange={(e) => {
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const next = [...transitions];
           next[idx] = { ...next[idx], from: e.target.value };
           setTransitions(next);
@@ -55,7 +55,7 @@ const TransitionInput: React.FC<TransitionInputProps> = ({
       />
       <VSCodeInput
         value={tr.to || ""}
-        onChange={(e) => {
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const next = [...transitions];
           next[idx] = { ...next[idx], to: e.target.value };
           setTransitions(next);
@@ -66,7 +66,7 @@ const TransitionInput: React.FC<TransitionInputProps> = ({
       />
       <VSCodeInput
         value={tr.condition || ""}
-        onChange={(e) => {
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const next = [...transitions];
           next[idx] = { ...next[idx], condition: e.target.value };
           setTransitions(next);
@@ -105,6 +105,7 @@ export default function ConversationFlowPropertiesPanel({
   const [transitions, setTransitions] = useState<
     { from: string; to: string; condition: string }[]
   >(() => node.data?.transitions || []);
+  const [statesError, setStatesError] = useState<string | null>(null);
 
   const handleFieldChange = (field: string, value: unknown) => {
     onChange({ ...node, data: { ...node.data, [field]: value } });
@@ -128,16 +129,32 @@ export default function ConversationFlowPropertiesPanel({
       >
         <VSCodeInput
           value={states.join(", ")}
-          onChange={(e) => {
-            const arr = e.target.value
-              .split(",")
-              .map((s) => s.trim())
-              .filter(Boolean);
-            setStates(arr);
-            handleFieldChange("states", arr);
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            try {
+              const arr = e.target.value
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean);
+              setStates(arr);
+              handleFieldChange("states", arr);
+              setStatesError(null);
+            } catch {
+              setStatesError("Invalid state list");
+            }
           }}
           placeholder="Comma separated states"
         />
+        {statesError && (
+          <div
+            style={{
+              color: theme.colors.error,
+              fontSize: theme.typography.fontSize.xs,
+              marginTop: theme.spacing.xs,
+            }}
+          >
+            {statesError}
+          </div>
+        )}
       </PanelSection>
       <PanelSection
         title="Initial State"
@@ -145,7 +162,7 @@ export default function ConversationFlowPropertiesPanel({
       >
         <VSCodeInput
           value={initialState}
-          onChange={(e) => {
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             setInitialState(e.target.value);
             handleFieldChange("initialState", e.target.value);
           }}
@@ -204,7 +221,7 @@ export default function ConversationFlowPropertiesPanel({
           <input
             type="checkbox"
             checked={persistState}
-            onChange={(e) => {
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               setPersistState(e.target.checked);
               handleFieldChange("persistState", e.target.checked);
             }}

--- a/agentflow/src/components/propertiesPanels/IfElsePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/IfElsePropertiesPanel.tsx
@@ -63,6 +63,8 @@ export default function IfElsePropertiesPanel({
         history: [],
         state: {},
       };
+  const [contextError, setContextError] = React.useState<string | null>(null);
+  const [stateError, setStateError] = React.useState<string | null>(null);
 
   return (
     <div
@@ -290,10 +292,13 @@ export default function IfElsePropertiesPanel({
           </label>
           <textarea
             value={JSON.stringify(ifElseData.context ?? {}, null, 2)}
-            onChange={(e) => {
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
               try {
                 handleFieldChange("context", JSON.parse(e.target.value));
-              } catch {}
+                setContextError(null);
+              } catch {
+                setContextError("Invalid JSON");
+              }
             }}
             placeholder='{"flowId": "...", "metadata": {}}'
             rows={4}
@@ -320,6 +325,18 @@ export default function IfElsePropertiesPanel({
               e.target.style.border = "1px solid #2a2a2a";
             }}
           />
+          {contextError && (
+            <div
+              style={{
+                fontSize: "10px",
+                color: "#f87171",
+                marginTop: "4px",
+                lineHeight: 1.4,
+              }}
+            >
+              {contextError}
+            </div>
+          )}
           <div
             style={{
               fontSize: "10px",
@@ -405,10 +422,13 @@ export default function IfElsePropertiesPanel({
           </label>
           <textarea
             value={JSON.stringify(ifElseData.state ?? {}, null, 2)}
-            onChange={(e) => {
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
               try {
                 handleFieldChange("state", JSON.parse(e.target.value));
-              } catch {}
+                setStateError(null);
+              } catch {
+                setStateError("Invalid JSON");
+              }
             }}
             placeholder={`{
   "key": "value"
@@ -437,6 +457,18 @@ export default function IfElsePropertiesPanel({
               e.target.style.border = "1px solid #2a2a2a";
             }}
           />
+          {stateError && (
+            <div
+              style={{
+                fontSize: "10px",
+                color: "#f87171",
+                marginTop: "4px",
+                lineHeight: 1.4,
+              }}
+            >
+              {stateError}
+            </div>
+          )}
           <div
             style={{
               fontSize: "10px",

--- a/agentflow/src/components/propertiesPanels/MessagePropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/MessagePropertiesPanel.tsx
@@ -175,7 +175,9 @@ export default function MessagePropertiesPanel({
           value={safeData.content}
           maxLength={500}
           placeholder="Message to send..."
-          onChange={(e) => handleFieldChange("content", e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            handleFieldChange("content", e.target.value)
+          }
           onBlur={() => setTouched((t) => ({ ...t, content: true }))}
         />
         <span
@@ -246,7 +248,9 @@ export default function MessagePropertiesPanel({
           <input
             type="checkbox"
             checked={!!safeData.passThrough}
-            onChange={(e) => handleFieldChange("passThrough", e.target.checked)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleFieldChange("passThrough", e.target.checked)
+            }
             id="passThrough"
             style={{
               accentColor: theme.colors.info,

--- a/agentflow/src/components/propertiesPanels/SimulatorPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/SimulatorPropertiesPanel.tsx
@@ -72,7 +72,7 @@ export default function SimulatorPropertiesPanel({
         <textarea
           style={textareaStyle}
           value={testInput}
-          onChange={(e) => {
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             setTestInput(e.target.value);
             handleFieldChange("testInput", e.target.value);
           }}
@@ -86,7 +86,7 @@ export default function SimulatorPropertiesPanel({
         <textarea
           style={textareaStyle}
           value={expectedOutput}
-          onChange={(e) => {
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             setExpectedOutput(e.target.value);
             handleFieldChange("expectedOutput", e.target.value);
           }}

--- a/agentflow/src/components/propertiesPanels/vsCodeFormComponents.tsx
+++ b/agentflow/src/components/propertiesPanels/vsCodeFormComponents.tsx
@@ -50,7 +50,9 @@ export const VSCodeSelect: React.FC<VSCodeSelectProps> = ({
 }) => (
   <select
     value={value}
-    onChange={(e) => onValueChange(e.target.value)}
+    onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+      onValueChange(e.target.value)
+    }
     style={{
       width: "100%",
       background: theme.colors.backgroundSecondary,


### PR DESCRIPTION
## Summary
- add React.ChangeEvent annotations to untyped onChange handlers in properties panels
- guard state list and JSON fields with try/catch blocks that display inline errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688fbfb4d364832cb8bc5ac4eafdf1f0