### PR TITLE
refactor: unify DashboardNodeData type

### DIFF
--- a/agentflow/eslint.config.mjs
+++ b/agentflow/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,6 +12,15 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {
+      "no-redeclare": "error",
+      "@typescript-eslint/no-redeclare": "error",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/agentflow/src/components/propertiesPanels/DashboardPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/DashboardPropertiesPanel.tsx
@@ -4,19 +4,13 @@ import {
   figmaPropertiesTheme as theme,
   getPanelContainerStyle,
 } from "./propertiesPanelTheme";
-import { CanvasNode } from "@/types";
+import { CanvasNode, DashboardNodeData } from "@/types";
 import { PanelSection } from "./PanelSection";
 import {
   VSCodeInput,
   VSCodeSelect,
   VSCodeButton,
 } from "./vsCodeFormComponents";
-
-interface DashboardNodeData {
-  widgets: string[];
-  title: string;
-  layout: string;
-}
 
 interface DashboardPropertiesPanelProps {
   node: CanvasNode;

--- a/agentflow/src/types/index.ts
+++ b/agentflow/src/types/index.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-// DashboardNodeData, TestCaseNodeData, ConversationFlowNodeData are defined in their respective panels, so we’ll define them here for type safety:
+// Node data types shared across the application for type safety
 export interface DashboardNodeData {
   widgets: string[];
   title: string;
@@ -69,12 +69,6 @@ export interface StateMachineNodeData {
 export interface SimulatorNodeData {
   testInput?: string;
   expectedOutput?: string;
-}
-
-export interface DashboardNodeData {
-  widgets: string[];
-  title: string;
-  layout: string;
 }
 
 export interface ConditionGroup {


### PR DESCRIPTION
## Summary
- consolidate `DashboardNodeData` into a single type definition and use it across the app
- add lint rule against duplicate declarations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbfc10f80832ca450fbf2eaa421b6