### PR TITLE
Fix auth redirects for login

### DIFF
--- a/agentflow/src/app/page.tsx
+++ b/agentflow/src/app/page.tsx
@@ -15,8 +15,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 
 export default function AgentFlowPage() {
-  const { user, session } = useAuth();
-  const loading = false; // If you have a loading state, set it here
+  const { user, loading } = useAuth();
   const router = useRouter();
 
   // Restore all required state variables

--- a/agentflow/src/components/AuthWrapper.tsx
+++ b/agentflow/src/components/AuthWrapper.tsx
@@ -16,7 +16,14 @@ export default function AuthWrapper({ children }: AuthWrapperProps) {
   const pathname = usePathname();
 
   // List of public routes that don't require authentication
-  const publicRoutes = ["/login", "/signup", "/forgot-password"];
+  const publicRoutes = [
+    "/auth/login",
+    "/auth/signup",
+    "/auth/reset-password",
+    "/login",
+    "/signup",
+    "/forgot-password",
+  ];
   const isPublicRoute = publicRoutes.includes(pathname);
 
   useEffect(() => {
@@ -31,8 +38,8 @@ export default function AuthWrapper({ children }: AuthWrapperProps) {
       // Redirect logic
       if (!session?.user && !isPublicRoute) {
         // User not logged in and trying to access protected route
-        router.push("/login");
-      } else if (session?.user && pathname === "/login") {
+        router.push("/auth/login");
+      } else if (session?.user && pathname === "/auth/login") {
         // User logged in but on login page
         router.push("/");
       }
@@ -51,7 +58,7 @@ export default function AuthWrapper({ children }: AuthWrapperProps) {
       if (event === "SIGNED_IN") {
         router.push("/");
       } else if (event === "SIGNED_OUT") {
-        router.push("/login");
+        router.push("/auth/login");
       }
     });
 


### PR DESCRIPTION
## Summary
- use AuthContext loading flag instead of constant to avoid login redirect loop
- allow `/auth/*` routes through AuthWrapper and redirect sign-outs to `/auth/login`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893b3970b70832c911c9fc36b4788dd