### PR TITLE
feat: add centralized logger

### DIFF
--- a/agentflow/src/app/api/stripe/route.ts
+++ b/agentflow/src/app/api/stripe/route.ts
@@ -2,6 +2,7 @@ import { stripe } from '@/lib/stripe';
 import { supabase } from '@/lib/supabaseClient';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { NextResponse } from 'next/server';
+import logger from '@/lib/logger';
 
 const getURL = () => {
   let url =
@@ -57,9 +58,9 @@ export async function POST(req: Request) {
     });
 
     return NextResponse.json({ sessionId: session.id });
-  } catch (err: any) {
-    console.log(err);
-    return new NextResponse('Error creating checkout session', { status: 500 });
-  }
+    } catch (err: any) {
+      logger.error(err);
+      return new NextResponse('Error creating checkout session', { status: 500 });
+    }
 }
 

--- a/agentflow/src/app/page.tsx
+++ b/agentflow/src/app/page.tsx
@@ -12,6 +12,7 @@ import PropertiesPanel from "@/components/panels/PropertiesPanel";
 import { nodeCategories } from "@/data/nodeDefinitions";
 import { runWorkflow } from "@/lib/workflowRunner";
 import { TESTER_V2_ENABLED } from "@/lib/flags";
+import logger from "@/lib/logger";
 
 const DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000000";
 
@@ -124,7 +125,7 @@ export default function AgentFlowPage() {
       const isJson = ct.includes("application/json");
       const payload = isJson ? await res.json().catch(() => []) : [];
       if (!res.ok) {
-        console.error("Error fetching projects:", payload);
+        logger.error("Error fetching projects:", payload);
         return;
       }
       const transformedProjects: Project[] = (payload || []).map((project: any) => ({
@@ -140,7 +141,7 @@ export default function AgentFlowPage() {
       }));
       setProjects(transformedProjects);
     } catch (err) {
-      console.error("Unexpected error fetching projects:", err);
+      logger.error("Unexpected error fetching projects:", err);
     }
   };
 
@@ -153,7 +154,7 @@ export default function AgentFlowPage() {
       const isJson = ct.includes("application/json");
       const payload = isJson ? await res.json().catch(() => []) : [];
       if (!res.ok) {
-        console.error("Error fetching nodes:", payload);
+        logger.error("Error fetching nodes:", payload);
         return;
       }
       const transformedNodes: CanvasNode[] = (payload || []).map((node: any) => ({
@@ -174,7 +175,7 @@ export default function AgentFlowPage() {
 
       setNodes(transformedNodes);
     } catch (err) {
-      console.error("Unexpected error fetching nodes:", err);
+      logger.error("Unexpected error fetching nodes:", err);
     }
   };
 
@@ -187,7 +188,7 @@ export default function AgentFlowPage() {
       const isJson = ct.includes("application/json");
       const payload = isJson ? await res.json().catch(() => []) : [];
       if (!res.ok) {
-        console.error("Error fetching connections:", payload);
+        logger.error("Error fetching connections:", payload);
         return;
       }
       const transformedConnections: Connection[] = (payload || []).map((conn: any) => ({
@@ -200,7 +201,7 @@ export default function AgentFlowPage() {
 
       setConnections(transformedConnections);
     } catch (err) {
-      console.error("Unexpected error fetching connections:", err);
+      logger.error("Unexpected error fetching connections:", err);
     }
   };
 
@@ -215,7 +216,7 @@ export default function AgentFlowPage() {
       });
       if (!res.ok) {
         const errText = await res.text();
-        console.error("Error updating start node:", errText);
+        logger.error("Error updating start node:", errText);
         return;
       }
       setCurrentProject({ ...currentProject, startNodeId: nodeId });
@@ -223,7 +224,7 @@ export default function AgentFlowPage() {
         prev.map((p) => (p.id === currentProject.id ? { ...p, startNodeId: nodeId } : p))
       );
     } catch (err) {
-      console.error("Unexpected error updating start node:", err);
+      logger.error("Unexpected error updating start node:", err);
     }
   };
 
@@ -232,12 +233,12 @@ export default function AgentFlowPage() {
   ) => {
     try {
       // Log environment check
-      console.log("Checking Supabase connection...");
-      console.log("Supabase URL exists:", !!process.env.NEXT_PUBLIC_SUPABASE_URL);
-      console.log("Supabase Anon Key exists:", !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+      logger.debug("Checking Supabase connection...");
+      logger.debug("Supabase URL exists:", !!process.env.NEXT_PUBLIC_SUPABASE_URL);
+      logger.debug("Supabase Anon Key exists:", !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 
       // Log input data
-      console.log("Creating project with data:", {
+      logger.debug("Creating project with data:", {
         name: projectData.name,
         description: projectData.description,
         status: projectData.status
@@ -251,7 +252,7 @@ export default function AgentFlowPage() {
         user_id: DEFAULT_USER_ID
       };
 
-      console.log("Attempting to insert project with data:", newProjectData);
+      logger.debug("Attempting to insert project with data:", newProjectData);
 
       const res = await fetch('/api/projects', {
         method: 'POST',
@@ -262,7 +263,7 @@ export default function AgentFlowPage() {
       const isJson = ct.includes('application/json');
       const payload = isJson ? await res.json().catch(() => null) : null;
       if (!res.ok || !payload) {
-        console.error('Project create failed:', payload);
+        logger.error('Project create failed:', payload);
         setStatusMessage(`Failed to create project: ${!res.ok ? res.status : 'No data returned'}`);
         return;
       }
@@ -290,7 +291,7 @@ export default function AgentFlowPage() {
       // Show success message
       setStatusMessage("Project created successfully");
     } catch (err) {
-      console.error("Unexpected error creating project:", err);
+      logger.error("Unexpected error creating project:", err);
       setStatusMessage("Failed to create project: Unexpected error");
     }
   };
@@ -408,15 +409,15 @@ export default function AgentFlowPage() {
         });
         if (!res.ok) {
           const t = await res.text();
-          console.error('Error saving new node:', t);
+          logger.error('Error saving new node:', t);
         }
       } catch (dbErr) {
-        console.error("Error saving new node:", dbErr);
+        logger.error("Error saving new node:", dbErr);
       }
 
       setNodes([...nodes, newNode]);
     } catch (err) {
-      console.error("Error adding node:", err);
+      logger.error("Error adding node:", err);
     }
   };
 
@@ -446,10 +447,10 @@ export default function AgentFlowPage() {
         });
         if (!res.ok) {
           const t = await res.text();
-          console.error('Error updating node:', t);
+          logger.error('Error updating node:', t);
         }
       } catch (dbErr) {
-        console.error("Error updating node:", dbErr);
+        logger.error("Error updating node:", dbErr);
       }
     }
   };
@@ -468,7 +469,7 @@ export default function AgentFlowPage() {
       const result = await runWorkflow(nodes, connections, startNodeId);
       setTestFlowResult(result);
     } catch (err) {
-      console.error("Error running workflow:", err);
+      logger.error("Error running workflow:", err);
       setTestFlowResult({
         error: err instanceof Error ? err.message : "Unknown error",
       });
@@ -479,7 +480,7 @@ export default function AgentFlowPage() {
 
   // Debug logging for connections state
   useEffect(() => {
-    console.log("Connections state updated:", connections);
+    logger.debug("Connections state updated:", connections);
   }, [connections]);
 
   // Persist connection deletions to Supabase
@@ -504,10 +505,10 @@ export default function AgentFlowPage() {
             });
             if (!res.ok) {
               const t = await res.text();
-              console.error('Error deleting connection:', r.id, t);
+              logger.error('Error deleting connection:', r.id, t);
             }
           } catch (err) {
-            console.error("Error deleting connection:", r.id, err);
+            logger.error("Error deleting connection:", r.id, err);
           }
         }
       })();
@@ -535,7 +536,7 @@ export default function AgentFlowPage() {
             });
             if (!resNode.ok) {
               const t = await resNode.text();
-              console.error('Error deleting node:', r.id, t);
+              logger.error('Error deleting node:', r.id, t);
             }
             // Related connections are deleted by DB cascade if defined; otherwise ensure cleanup
             const resConn = await fetch(`/api/projects/${currentProject.id}/connections?project_id=${currentProject.id}`, {
@@ -553,7 +554,7 @@ export default function AgentFlowPage() {
               }
             }
           } catch (err) {
-            console.error("Error deleting node or its connections:", r.id, err);
+            logger.error("Error deleting node or its connections:", r.id, err);
           }
         }
       })();
@@ -615,10 +616,10 @@ export default function AgentFlowPage() {
                 });
                 if (!res.ok) {
                   const t = await res.text();
-                  console.error('Error creating connection:', t);
+                  logger.error('Error creating connection:', t);
                 }
               } catch (err) {
-                console.error("Error creating connection:", err);
+                logger.error("Error creating connection:", err);
               }
             }}
             showTester={showTester}

--- a/agentflow/src/components/dashboard/FolderTree.tsx
+++ b/agentflow/src/components/dashboard/FolderTree.tsx
@@ -3,6 +3,7 @@ import { ChevronRight, ChevronDown, Folder, FolderOpen, File, Plus } from 'lucid
 import { cn } from '@/lib/utils';
 import { supabase } from '@/lib/supabaseClient';
 import type { Project } from '@/types/project';
+import logger from '@/lib/logger';
 
 interface Folder {
   id: string;
@@ -36,7 +37,7 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
 
   const fetchFolders = async () => {
     try {
-      console.log('Fetching folders...');
+      logger.debug('Fetching folders...');
       
       const { data, error } = await supabase
         .from('folders')
@@ -49,8 +50,8 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
         .order('created_at');
 
       if (error) {
-        console.error('Error fetching folders:', error);
-        console.error('Error details:', {
+      logger.error('Error fetching folders:', error);
+      logger.error('Error details:', {
           code: error.code,
           message: error.message,
           details: error.details,
@@ -59,7 +60,7 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
         return;
       }
 
-      console.log('Fetched folders:', data);
+      logger.debug('Fetched folders:', data);
 
       // Transform the flat folder list into a tree structure
       const folderMap = new Map<string, Folder>();
@@ -87,13 +88,13 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
 
       setFolders(rootFolders);
     } catch (err) {
-      console.error('Error in fetchFolders:', err);
+      logger.error('Error in fetchFolders:', err);
     }
   };
 
   const handleCreateFolder = async (parentId: string | null) => {
     try {
-      console.log('Creating folder with parent:', parentId);
+      logger.debug('Creating folder with parent:', parentId);
       
       const newFolder = {
         name: 'New Folder',
@@ -101,7 +102,7 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
         user_id: '00000000-0000-0000-0000-000000000000'
       };
       
-      console.log('Folder data:', newFolder);
+      logger.debug('Folder data:', newFolder);
 
       const { data, error } = await supabase
         .from('folders')
@@ -110,8 +111,8 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
         .single();
 
       if (error) {
-        console.error('Error creating folder:', error);
-        console.error('Error details:', {
+        logger.error('Error creating folder:', error);
+        logger.error('Error details:', {
           code: error.code,
           message: error.message,
           details: error.details,
@@ -121,15 +122,15 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
       }
 
       if (!data) {
-        console.error('No data returned from folder creation');
+      logger.error('No data returned from folder creation');
         return;
       }
 
-      console.log('Folder created successfully:', data);
+      logger.debug('Folder created successfully:', data);
       setEditingFolderId(data.id);
       await fetchFolders();
     } catch (err) {
-      console.error('Unexpected error creating folder:', err);
+      logger.error('Unexpected error creating folder:', err);
     }
   };
 
@@ -141,14 +142,14 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
         .eq('id', folderId);
 
       if (error) {
-        console.error('Error updating folder name:', error);
+        logger.error('Error updating folder name:', error);
         return;
       }
 
       setEditingFolderId(null);
       await fetchFolders();
     } catch (err) {
-      console.error('Error updating folder name:', err);
+      logger.error('Error updating folder name:', err);
     }
   };
 
@@ -167,7 +168,7 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
         }]);
 
       if (error) {
-        console.error('Error moving project to folder:', error);
+        logger.error('Error moving project to folder:', error);
         return;
       }
 
@@ -177,7 +178,7 @@ export default function FolderTree({ onSelectProject, onSelectFolder, selectedPr
       (window as any).draggedProjectId = null;
       await fetchFolders();
     } catch (err) {
-      console.error('Error moving project to folder:', err);
+      logger.error('Error moving project to folder:', err);
     }
   };
 

--- a/agentflow/src/components/nodes/ChatBoxNode.tsx
+++ b/agentflow/src/components/nodes/ChatBoxNode.tsx
@@ -5,6 +5,7 @@ import {
   selectedNodeStyle,
   hoverNodeStyle
 } from './nodeStyles';
+import logger from '@/lib/logger';
 
 interface ChatBoxNodeProps {
   node: CanvasNode;
@@ -56,16 +57,16 @@ export default function ChatBoxNode(props: ChatBoxNodeProps) {
 
   // Update node data when input changes
   const handleInputChange = (value: string) => {
-    console.log('Input changed to:', value); // Add this
+      logger.debug('Input changed to:', value);
     setInput(value);
     const updatedNode = {
       ...node,
       data: { ...node.data, inputValue: value }
     };
-    console.log('Updated node data:', updatedNode.data); // Add this
-    console.log('Calling onNodeUpdate...'); // Debug log
-    onNodeUpdate(updatedNode);
-    console.log('onNodeUpdate called'); // Debug log
+      logger.debug('Updated node data:', updatedNode.data);
+      logger.debug('Calling onNodeUpdate...');
+      onNodeUpdate(updatedNode);
+      logger.debug('onNodeUpdate called');
   };
 
   const nodeStyle: React.CSSProperties = {

--- a/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
+++ b/agentflow/src/components/propertiesPanels/AgentPropertiesPanel.tsx
@@ -21,6 +21,7 @@ import {
   VSCodeSelect,
   VSCodeButton,
 } from "./vsCodeFormComponents";
+import logger from "@/lib/logger";
 
 interface AgentNodeData {
   name?: string;
@@ -345,7 +346,7 @@ export default function AgentPropertiesPanel({
               size="small"
               onClick={() => {
                 // Trigger agent test
-                console.log("Testing agent with current configuration...");
+                logger.debug("Testing agent with current configuration...");
               }}
             >
               Test Agent
@@ -406,7 +407,7 @@ export default function AgentPropertiesPanel({
             style={{ width: "100%" }}
             onClick={() => {
               // Open chat preview
-              console.log("Opening chat preview...");
+              logger.debug("Opening chat preview...");
             }}
           >
             <MessageSquare

--- a/agentflow/src/lib/geminiClient.ts
+++ b/agentflow/src/lib/geminiClient.ts
@@ -1,4 +1,6 @@
 // Gemini API utility for workflow execution (v1beta)
+import logger from "./logger";
+
 export async function callGemini(prompt: string, params: Record<string, unknown> = {}) {
   const GEMINI_API_KEY = process.env.NEXT_PUBLIC_GEMINI_API_KEY;
   if (!GEMINI_API_KEY) {
@@ -29,9 +31,8 @@ export async function callGemini(prompt: string, params: Record<string, unknown>
   if (typeof window !== "undefined" && window?.localStorage) {
     window.localStorage.setItem("__gemini_debug_body__", JSON.stringify(body, null, 2));
   }
-  // Also log to console (Node or browser)
-  // eslint-disable-next-line no-console
-  console.log("[Gemini Debug] Outgoing Gemini payload:", body);
+  // Also log in debug mode (Node or browser)
+  logger.debug("[Gemini Debug] Outgoing Gemini payload:", body);
 
 
   const res = await fetch(`${url}?key=${GEMINI_API_KEY}`, {

--- a/agentflow/src/lib/logger.ts
+++ b/agentflow/src/lib/logger.ts
@@ -1,0 +1,14 @@
+const DEBUG_ENABLED = process.env.NODE_ENV !== 'production' || ['1','true','yes','on'].includes((process.env.NEXT_PUBLIC_DEBUG || process.env.DEBUG || '').toLowerCase());
+
+const logger = {
+  debug: (...args: unknown[]) => {
+    if (DEBUG_ENABLED) {
+      console.log(...args);
+    }
+  },
+  error: (...args: unknown[]) => {
+    console.error(...args);
+  },
+};
+
+export default logger;

--- a/agentflow/src/lib/mcp/server.ts
+++ b/agentflow/src/lib/mcp/server.ts
@@ -5,6 +5,7 @@ import { CanvasNode, Connection, ProjectFile } from '@/types';
 import getPort, { portNumbers } from 'get-port';
 import http from 'http';
 import { CURRENT_EXPORT_VERSION, getMcpExportSchema } from './schema';
+import logger from './logger';
 
 const app = express();
 
@@ -16,8 +17,8 @@ const runningServers: Map<string, http.Server> =
   globalAny.__agentflowMcpServers || (globalAny.__agentflowMcpServers = new Map());
 
 export const startMcpServer = async (projectId: string): Promise<number> => {
-  if (runningServers.has(projectId)) {
-    console.log(`Server for project ${projectId} is already running.`);
+    if (runningServers.has(projectId)) {
+      logger.debug(`Server for project ${projectId} is already running.`);
     const server = runningServers.get(projectId);
     const address = server?.address();
     if (typeof address === 'object' && address !== null) {
@@ -64,7 +65,7 @@ export const startMcpServer = async (projectId: string): Promise<number> => {
       );
       res.json(mcpData);
     } catch (error) {
-      console.error('Error fetching project data for MCP:', error);
+        logger.error('Error fetching project data for MCP:', error);
       res.status(500).json({ error: 'Failed to fetch project data' });
     }
   });
@@ -110,14 +111,14 @@ export const startMcpServer = async (projectId: string): Promise<number> => {
       }
       res.redirect(signed.signedUrl);
     } catch (err) {
-      console.error('Error generating file download URL:', err);
+        logger.error('Error generating file download URL:', err);
       res.status(500).json({ error: 'Failed to generate file download URL' });
     }
   });
 
   return new Promise((resolve) => {
     server.listen(port, '127.0.0.1', () => {
-      console.log(`MCP Server started for project ${projectId} on http://localhost:${port}`);
+        logger.debug(`MCP Server started for project ${projectId} on http://localhost:${port}`);
       runningServers.set(projectId, server);
       resolve(port);
     });
@@ -129,12 +130,12 @@ export const stopMcpServer = (projectId: string): Promise<void> => {
         const server = runningServers.get(projectId);
         if (server) {
             server.close(() => {
-                console.log(`MCP Server for project ${projectId} stopped.`);
+                  logger.debug(`MCP Server for project ${projectId} stopped.`);
                 runningServers.delete(projectId);
                 resolve();
             });
         } else {
-            console.log(`No server found for project ${projectId}.`);
+              logger.debug(`No server found for project ${projectId}.`);
             resolve();
         }
     });

--- a/agentflow/src/lib/workflowRunner.ts
+++ b/agentflow/src/lib/workflowRunner.ts
@@ -3,6 +3,7 @@ import type { TesterEvent } from "@/types/tester";
 import type { RunExecutionOptions } from "@/types/run";
 import { FlowEngine } from "./flow/FlowEngine";
 import { evaluateAssertions } from "@/lib/assertions";
+import logger from "./logger";
 
 // Helper to safely get node title
 function getNodeTitle(node: CanvasNode): string {
@@ -61,17 +62,17 @@ export async function runWorkflow(
       });
       const header = `Assertions: ${result.passed ? "PASSED" : "FAILED"} (${result.results.filter(r=>r.pass).length}/${result.results.length})`;
       if (emitLog) emitLog("flow", header, result as unknown, result.passed ? undefined : "Some assertions failed");
-      else console.log("[Tester]", header, result);
+      else logger.debug("[Tester]", header, result);
       // Also log each assertion result for clarity
       for (const r of result.results) {
         const msg = `${r.pass ? "✓" : "✗"} ${r.description || r.op}${r.path ? ` @ ${r.path}` : ""} → ${r.pass ? "pass" : "fail"}. ${r.message}`;
-        if (emitLog) emitLog("flow", msg);
-        else console.log("[Tester]", msg);
+          if (emitLog) emitLog("flow", msg);
+          else logger.debug("[Tester]", msg);
       }
     } catch (err) {
       const emsg = err instanceof Error ? err.message : String(err);
       if (emitLog) emitLog("flow", "Assertions evaluation error", undefined, emsg);
-      else console.warn("[Tester] Assertions evaluation error:", err);
+      else logger.error("[Tester] Assertions evaluation error:", err);
     }
   }
 


### PR DESCRIPTION
## Summary
- add centralized logger with env-based debug toggle
- replace console.log calls with logger across workflow runner, canvas, and misc components
- ensure production builds suppress debug logs while keeping error output

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any & unused vars)


------
https://chatgpt.com/codex/tasks/task_e_689914f72b6c832ca3da9e1f65c75f0f