### PR TITLE
Validate environment variables with Zod helper

### DIFF
--- a/agentflow/package.json
+++ b/agentflow/package.json
@@ -28,7 +28,8 @@
     "react-dom": "19.1.0",
     "react-draggable": "^4.5.0",
     "stripe": "^18.4.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/agentflow/src/app/api/llm/nvidia/route.ts
+++ b/agentflow/src/app/api/llm/nvidia/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/lib/env";
 
 // Prefer server-only env vars if present; fallback to NEXT_PUBLIC_* for now
-const NVIDIA_API_KEY = process.env.NVIDIA_API_KEY || process.env.NEXT_PUBLIC_NVIDIA_API_KEY;
-const RAW_BASE = process.env.NVIDIA_BASE_URL || process.env.NEXT_PUBLIC_NVIDIA_BASE_URL || "https://integrate.api.nvidia.com/v1";
+const NVIDIA_API_KEY = env.NVIDIA_API_KEY || env.NEXT_PUBLIC_NVIDIA_API_KEY;
+const RAW_BASE =
+  env.NVIDIA_BASE_URL || env.NEXT_PUBLIC_NVIDIA_BASE_URL || "https://integrate.api.nvidia.com/v1";
 // Normalize base URL to ensure it includes /v1
 function normalizeBase(url: string): string {
   const trimmed = url.replace(/\/$/, "");

--- a/agentflow/src/lib/env.ts
+++ b/agentflow/src/lib/env.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z
+    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_URL is required' })
+    .url('NEXT_PUBLIC_SUPABASE_URL must be a valid URL'),
+  SUPABASE_SERVICE_ROLE_KEY: z
+    .string({ required_error: 'SUPABASE_SERVICE_ROLE_KEY is required' })
+    .min(1, 'SUPABASE_SERVICE_ROLE_KEY is required'),
+  NVIDIA_API_KEY: z.string().optional(),
+  NEXT_PUBLIC_NVIDIA_API_KEY: z.string().optional(),
+  NVIDIA_BASE_URL: z.string().optional(),
+  NEXT_PUBLIC_NVIDIA_BASE_URL: z.string().optional(),
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  const issues = parsed.error.issues
+    .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+    .join('; ');
+  throw new Error(`Environment variable validation error: ${issues}`);
+}
+
+export const env = parsed.data;
+export type Env = typeof env;

--- a/agentflow/src/lib/supabaseAdmin.ts
+++ b/agentflow/src/lib/supabaseAdmin.ts
@@ -1,16 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-if (!supabaseUrl) {
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL for Supabase');
-}
-if (!serviceRoleKey) {
-  throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY for Supabase admin client');
-}
-
-export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+export const supabaseAdmin = createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
   auth: {
     persistSession: false,
     autoRefreshToken: false,


### PR DESCRIPTION
## Summary
- add Zod-based environment parser for required variables
- use env helper in Supabase admin client and NVIDIA API route
- declare zod dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many lint errors; see log)*

------
https://chatgpt.com/codex/tasks/task_e_689914f997b8832cb894185a40de1f7f