### PR TITLE
docs: refresh README with setup details

### DIFF
--- a/agentflow/README.md
+++ b/agentflow/README.md
@@ -1,41 +1,36 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Weev
 
-## Getting Started
+Weev is a visual AI agent design platform that lets you connect and orchestrate nodes to build AI workflows. It is built with Next.js and Supabase to provide a fast, interactive design experience.
 
-First, run the development server:
+## Prerequisites
+
+- Node.js 18+
+- npm (or another Node package manager)
+
+## Run
+
+Install dependencies and start the development server:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Build and run in production:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm run build
+npm start
+```
 
 ## Environment Variables
 
-Set `NEXT_PUBLIC_GEMINI_API_KEY` in your environment (for example in `.env.local`) with your Gemini API key.
+The application relies on the following environment variables (e.g. in `.env.local`):
 
-## Learn More
+- `NEXT_PUBLIC_GEMINI_API_KEY` – API key for Google Gemini.
+- `SUPABASE_SERVICE_ROLE_KEY` – service role key for Supabase access.
+- `NVIDIA_API_KEY` – key for NVIDIA AI endpoints.
 
-To learn more about Next.js, take a look at the following resources:
+## Architecture
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+For details about node contracts and data flow, see [docs/DataFlowContract.md](docs/DataFlowContract.md).


### PR DESCRIPTION
## Summary
- Replace boilerplate README with a Weev overview and usage instructions
- Document environment variables including SUPABASE_SERVICE_ROLE_KEY and NVIDIA_API_KEY
- Link to docs/DataFlowContract.md for architecture details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689914fc305c832c8f3f0ab791b374ba