### PR TITLE
Add simple in-memory rate limiting to API routes

### DIFF
--- a/agentflow/src/app/api/mcp/start/route.ts
+++ b/agentflow/src/app/api/mcp/start/route.ts
@@ -1,7 +1,14 @@
 import { startMcpServer } from '@/lib/mcp/server';
 import { NextResponse } from 'next/server';
+import { checkRateLimit, getClientIp } from '@/lib/utils';
 
 export async function POST(req: Request) {
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip)) {
+    console.warn(`Rate limit exceeded for ${ip} on POST /api/mcp/start`);
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const { projectId } = await req.json();
 
   if (!projectId) {

--- a/agentflow/src/lib/utils.ts
+++ b/agentflow/src/lib/utils.ts
@@ -33,3 +33,27 @@ export function formatRelativeTime(date: string | number | Date): string {
     return ''
   }
 }
+
+// Simple in-memory request limiter
+type RateRecord = {
+  count: number
+  reset: number
+}
+
+const rateStore = new Map<string, RateRecord>()
+
+export function checkRateLimit(key: string, limit = 60, windowMs = 60_000): boolean {
+  const now = Date.now()
+  const record = rateStore.get(key)
+  if (!record || record.reset <= now) {
+    rateStore.set(key, { count: 1, reset: now + windowMs })
+    return true
+  }
+  if (record.count >= limit) return false
+  record.count++
+  return true
+}
+
+export function getClientIp(req: Request): string {
+  return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
+}


### PR DESCRIPTION
## Summary
- add basic in-memory rate limiter utility
- wrap NVIDIA LLM and MCP start endpoints with limiter returning 429

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689914ff4d3c832cbd952bbfa94d2921