### PR TITLE
chore: add Prettier and formatting script

### DIFF
--- a/agentflow/.husky/pre-commit
+++ b/agentflow/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm run format

--- a/agentflow/.prettierrc
+++ b/agentflow/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2
+}

--- a/agentflow/package.json
+++ b/agentflow/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "mcp": "node src/lib/mcp/server.ts"
+    "mcp": "node src/lib/mcp/server.ts",
+    "format": "prettier --write .",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
@@ -40,6 +42,8 @@
     "eslint-config-next": "15.4.3",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.5",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prettier": "^3.3.3",
+    "husky": "^9.0.11"
   }
 }


### PR DESCRIPTION
## Summary
- add Prettier config for single quotes and 2-space indentation
- add format and prepare scripts along with Prettier and Husky dev dependencies
- create a Husky pre-commit hook to run formatting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: multiple lint errors)
- `npm run format` (fails: prettier not found)

------
https://chatgpt.com/codex/tasks/task_e_689914fe385c832c9b0fe430888a7760