### PR TITLE
feat: scaffold front-of-house layout

### DIFF
--- a/agentflow/src/app/front/page.tsx
+++ b/agentflow/src/app/front/page.tsx
@@ -1,0 +1,5 @@
+import FrontOfHouseLayout from "@/components/front/FrontOfHouseLayout";
+
+export default function FrontPage() {
+  return <FrontOfHouseLayout />;
+}

--- a/agentflow/src/components/front/ContentView.tsx
+++ b/agentflow/src/components/front/ContentView.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { LayoutGrid, Table } from "lucide-react";
+
+const sampleProjects = [
+  { id: "p1", name: "Email Bot", updated: "2d ago" },
+  { id: "p2", name: "Marketing Flow", updated: "5d ago" },
+];
+
+export function ContentView() {
+  const [view, setView] = useState<"grid" | "table">("grid");
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="flex justify-end gap-2 p-2 border-b">
+        <button
+          className={`p-1 rounded ${view === "grid" ? "bg-muted" : ""}`}
+          onClick={() => setView("grid")}
+        >
+          <LayoutGrid className="w-4 h-4" />
+        </button>
+        <button
+          className={`p-1 rounded ${view === "table" ? "bg-muted" : ""}`}
+          onClick={() => setView("table")}
+        >
+          <Table className="w-4 h-4" />
+        </button>
+      </div>
+      {view === "grid" ? (
+        <div className="p-4 grid grid-cols-2 gap-4">
+          {sampleProjects.map((p) => (
+            <div key={p.id} className="border rounded p-4 shadow-sm">
+              <div className="h-24 bg-muted mb-2" />
+              <div className="font-medium">{p.name}</div>
+              <div className="text-sm text-muted-foreground">{p.updated}</div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Name</th>
+              <th className="p-2">Last Edited</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sampleProjects.map((p) => (
+              <tr key={p.id} className="border-t">
+                <td className="p-2">{p.name}</td>
+                <td className="p-2">{p.updated}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default ContentView;

--- a/agentflow/src/components/front/ContextDrawer.tsx
+++ b/agentflow/src/components/front/ContextDrawer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { X } from "lucide-react";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ContextDrawer({ open, onClose }: Props) {
+  if (!open) return null;
+  return (
+    <div className="w-64 border-l p-4 space-y-2">
+      <div className="flex justify-between items-center">
+        <h2 className="font-semibold">Details</h2>
+        <button onClick={onClose} className="p-1 rounded hover:bg-muted">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Select a project to see details.
+      </p>
+    </div>
+  );
+}
+
+export default ContextDrawer;

--- a/agentflow/src/components/front/FocusStrip.tsx
+++ b/agentflow/src/components/front/FocusStrip.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+const items = ["Recent", "Pinned", "Shared", "Templates"];
+
+export function FocusStrip() {
+  return (
+    <div className="flex gap-2 p-2 border-b">
+      {items.map((item) => (
+        <button
+          key={item}
+          className="px-3 py-1 text-sm rounded-full bg-muted hover:bg-muted/70"
+        >
+          {item}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default FocusStrip;

--- a/agentflow/src/components/front/FolderPanel.tsx
+++ b/agentflow/src/components/front/FolderPanel.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, FolderPlus, Plus, Import, Star } from "lucide-react";
+
+interface FolderItem {
+  id: string;
+  name: string;
+  children?: FolderItem[];
+}
+
+const sampleFolders: FolderItem[] = [
+  { id: "1", name: "Favorites", children: [{ id: "p1", name: "Project A" }] },
+  { id: "2", name: "Shared with me" },
+  { id: "3", name: "All Folders" },
+];
+
+function FolderNode({ item }: { item: FolderItem }) {
+  const [open, setOpen] = useState(true);
+  const hasChildren = item.children && item.children.length > 0;
+  return (
+    <div className="ml-2">
+      <div
+        className="flex items-center gap-1 cursor-pointer hover:text-accent"
+        onClick={() => setOpen(!open)}
+      >
+        {hasChildren && (
+          open ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />
+        )}
+        <span>{item.name}</span>
+      </div>
+      {hasChildren && open && (
+        <div className="ml-4 mt-1 space-y-1">
+          {item.children!.map((child) => (
+            <div key={child.id} className="text-sm text-muted-foreground">
+              {child.name}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function FolderPanel() {
+  return (
+    <aside className="w-56 border-r p-2 space-y-2">
+      <div className="flex gap-2 text-sm">
+        <button className="flex-1 flex items-center gap-1 px-2 py-1 rounded hover:bg-muted">
+          <FolderPlus className="w-4 h-4" /> New Folder
+        </button>
+        <button className="flex-1 flex items-center gap-1 px-2 py-1 rounded hover:bg-muted">
+          <Plus className="w-4 h-4" /> Project
+        </button>
+        <button className="flex-1 flex items-center gap-1 px-2 py-1 rounded hover:bg-muted">
+          <Import className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="space-y-1 text-sm">
+        {sampleFolders.map((item) => (
+          <FolderNode key={item.id} item={item} />
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+export default FolderPanel;

--- a/agentflow/src/components/front/FrontOfHouseLayout.tsx
+++ b/agentflow/src/components/front/FrontOfHouseLayout.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import LeftRail from "./LeftRail";
+import FolderPanel from "./FolderPanel";
+import HeaderBar from "./HeaderBar";
+import FocusStrip from "./FocusStrip";
+import ContentView from "./ContentView";
+import ContextDrawer from "./ContextDrawer";
+
+export function FrontOfHouseLayout() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  return (
+    <div className="flex h-screen">
+      <LeftRail />
+      <FolderPanel />
+      <div className="flex flex-col flex-1">
+        <HeaderBar />
+        <FocusStrip />
+        <ContentView />
+      </div>
+      <ContextDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+    </div>
+  );
+}
+
+export default FrontOfHouseLayout;

--- a/agentflow/src/components/front/HeaderBar.tsx
+++ b/agentflow/src/components/front/HeaderBar.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Bell, ChevronDown, Search, Plus } from "lucide-react";
+
+export function HeaderBar() {
+  return (
+    <header className="flex items-center justify-between gap-4 border-b p-2">
+      <div className="flex items-center gap-2 flex-1">
+        <Search className="w-5 h-5 text-muted-foreground" />
+        <input
+          type="text"
+          placeholder="Search projects, nodes, people"
+          className="flex-1 bg-transparent outline-none"
+        />
+        <div className="flex gap-2 text-sm">
+          <span className="px-2 py-1 bg-muted rounded-full">Owner</span>
+          <span className="px-2 py-1 bg-muted rounded-full">Type</span>
+          <span className="px-2 py-1 bg-muted rounded-full">Updated</span>
+        </div>
+      </div>
+      <div className="flex items-center gap-4">
+        <button className="flex items-center gap-1 px-3 py-1 bg-accent text-accent-foreground rounded">
+          <Plus className="w-4 h-4" /> Create
+        </button>
+        <Bell className="w-5 h-5" />
+        <div className="w-8 h-8 bg-muted rounded-full" />
+      </div>
+    </header>
+  );
+}
+
+export default HeaderBar;

--- a/agentflow/src/components/front/LeftRail.tsx
+++ b/agentflow/src/components/front/LeftRail.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Home, FolderKanban, FileStack, Trash2, Settings } from "lucide-react";
+import Link from "next/link";
+
+const items = [
+  { href: "#", icon: Home, label: "Home" },
+  { href: "#", icon: FolderKanban, label: "Projects" },
+  { href: "#", icon: FileStack, label: "Templates" },
+  { href: "#", icon: Trash2, label: "Trash" },
+  { href: "#", icon: Settings, label: "Settings" },
+];
+
+export function LeftRail() {
+  return (
+    <aside className="flex flex-col items-center gap-4 py-4 w-14 border-r bg-background">
+      {items.map(({ href, icon: Icon, label }) => (
+        <Link key={label} href={href} className="p-2 rounded hover:bg-muted">
+          <Icon className="w-5 h-5" aria-label={label} />
+        </Link>
+      ))}
+    </aside>
+  );
+}
+
+export default LeftRail;


### PR DESCRIPTION
## Summary
- add initial front-of-house layout with left rail, folder panel, header, focus strip, and grid/table content
- include basic context drawer and route at `/front`

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build` *(fails: Failed to fetch Google Fonts; webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_68991a5c0f78832ca0ab8f2867acb577