### PR TITLE
Refactor API auth handling for projects and Stripe routes

### DIFF
--- a/agentflow/src/app/api/projects/route.ts
+++ b/agentflow/src/app/api/projects/route.ts
@@ -1,23 +1,12 @@
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { getAuthedUser } from '@/lib/auth';
 
 const DEFAULT_USER_ID = '00000000-0000-0000-0000-000000000000';
 
 // GET all projects
-export async function GET(req) {
+export async function GET(req: Request) {
   try {
-    const authHeader = req.headers.get('authorization') || req.headers.get('Authorization');
-    let authedUserId = null;
-    if (authHeader?.startsWith('Bearer ')) {
-      const token = authHeader.slice('Bearer '.length);
-      try {
-        const { data: userData, error: userErr } = await supabaseAdmin.auth.getUser(token);
-        if (!userErr && userData?.user?.id) {
-          authedUserId = userData.user.id;
-        }
-      } catch {
-        // ignore and fall back to unscoped
-      }
-    }
+    const authedUserId = (await getAuthedUser(req))?.id ?? null;
 
     // If we have a valid user, try to scope by user_id. If column missing, fall back to unscoped.
     if (authedUserId) {
@@ -26,7 +15,9 @@ export async function GET(req) {
         .select('*')
         .eq('user_id', authedUserId);
       if (!scoped.error) {
-        return new Response(JSON.stringify(scoped.data || []), { headers: { 'Content-Type': 'application/json' } });
+        return new Response(JSON.stringify(scoped.data || []), {
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
       // fall through to unscoped on error (e.g., missing column)
     }
@@ -38,7 +29,9 @@ export async function GET(req) {
         { status: 500, headers: { 'Content-Type': 'application/json' } }
       );
     }
-    return new Response(JSON.stringify(unscoped.data || []), { headers: { 'Content-Type': 'application/json' } });
+    return new Response(JSON.stringify(unscoped.data || []), {
+      headers: { 'Content-Type': 'application/json' },
+    });
   } catch (e) {
     return new Response(
       JSON.stringify({ error: e instanceof Error ? e.message : 'Unknown error' }),
@@ -48,22 +41,10 @@ export async function GET(req) {
 }
 
 // POST create new project
-export async function POST(req) {
+export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const authHeader = req.headers.get('authorization') || req.headers.get('Authorization');
-    let authedUserId = null;
-    if (authHeader?.startsWith('Bearer ')) {
-      const token = authHeader.slice('Bearer '.length);
-      try {
-        const { data: userData, error: userErr } = await supabaseAdmin.auth.getUser(token);
-        if (!userErr && userData?.user?.id) {
-          authedUserId = userData.user.id;
-        }
-      } catch {
-        // ignore and continue without user scope
-      }
-    }
+    const authedUserId = (await getAuthedUser(req))?.id ?? null;
 
     const baseInsert = {
       name: body?.name ?? 'Untitled Project',
@@ -83,7 +64,9 @@ export async function POST(req) {
         .select()
         .single();
       if (!first.error) {
-        return new Response(JSON.stringify(first.data), { headers: { 'Content-Type': 'application/json' } });
+        return new Response(JSON.stringify(first.data), {
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
       // fall through to try without user_id
     } else {
@@ -93,7 +76,9 @@ export async function POST(req) {
         .select()
         .single();
       if (!withDefault.error) {
-        return new Response(JSON.stringify(withDefault.data), { headers: { 'Content-Type': 'application/json' } });
+        return new Response(JSON.stringify(withDefault.data), {
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
       // fall through to try without user_id (covers schemas where user_id column doesn't exist)
     }
@@ -109,7 +94,9 @@ export async function POST(req) {
         { status: 500, headers: { 'Content-Type': 'application/json' } }
       );
     }
-    return new Response(JSON.stringify(fallback.data), { headers: { 'Content-Type': 'application/json' } });
+    return new Response(JSON.stringify(fallback.data), {
+      headers: { 'Content-Type': 'application/json' },
+    });
   } catch (e) {
     return new Response(
       JSON.stringify({ error: e instanceof Error ? e.message : 'Unknown error' }),

--- a/agentflow/src/app/api/stripe/route.ts
+++ b/agentflow/src/app/api/stripe/route.ts
@@ -1,16 +1,13 @@
 import { stripe } from '@/lib/stripe';
-import { supabase } from '@/lib/supabaseClient';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { getAuthedUser } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 
 const getURL = () => {
   let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ?? // Set this to your site URL in production
-    process?.env?.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
+    process?.env?.NEXT_PUBLIC_SITE_URL ??
+    process?.env?.NEXT_PUBLIC_VERCEL_URL ??
     'http://localhost:3000/';
-  // Make sure to include `https://` when not localhost.
   url = url.includes('http') ? url : `https://${url}`;
-  // Make sure to include a trailing `/`.
   url = url.charAt(url.length - 1) === '/' ? url : `${url}/`;
   return url;
 };
@@ -18,25 +15,16 @@ const getURL = () => {
 export async function POST(req: Request) {
   const { price, quantity = 1, metadata = {} } = await req.json();
 
-  try {
-    // For now, we'll use a hardcoded user. In a real application, you'd get this from your authentication system.
-    const user = { id: 'user_placeholder_id', email: 'user@example.com' };
+  const user = await getAuthedUser(req);
+  if (!user) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
 
-    let customer;
-    // In a real app, you would fetch the user's Stripe customer ID from your database.
-    // const { data: profile } = await supabase.from('profiles').select('stripe_customer_id').eq('id', user.id).single();
-    // if (profile?.stripe_customer_id) {
-    //   customer = { id: profile.stripe_customer_id };
-    // } else {
-      customer = await stripe.customers.create({
-        email: user.email,
-        metadata: {
-          userId: user.id,
-        },
-      });
-      // And you would save the new customer ID to your database.
-      // await supabase.from('profiles').update({ stripe_customer_id: customer.id }).eq('id', user.id);
-    // }
+  try {
+    const customer = await stripe.customers.create({
+      email: user.email,
+      metadata: { userId: user.id },
+    });
 
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
@@ -62,4 +50,3 @@ export async function POST(req: Request) {
     return new NextResponse('Error creating checkout session', { status: 500 });
   }
 }
-

--- a/agentflow/src/lib/auth.ts
+++ b/agentflow/src/lib/auth.ts
@@ -1,0 +1,22 @@
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export interface AuthedUser {
+  id: string;
+  email?: string;
+}
+
+export async function getAuthedUser(req: Request): Promise<AuthedUser | null> {
+  const authHeader = req.headers.get('authorization') || req.headers.get('Authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice('Bearer '.length);
+    try {
+      const { data, error } = await supabaseAdmin.auth.getUser(token);
+      if (!error && data?.user) {
+        return { id: data.user.id, email: data.user.email ?? undefined };
+      }
+    } catch {
+      // ignore errors and fall through
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- extract shared `getAuthedUser` helper for Supabase-based auth
- convert projects API route to TypeScript and use shared auth logic
- require authenticated user for Stripe checkout sessions and remove hardcoded placeholder

## Testing
- `npm test` *(fails: RouterNode and ThinkingNode specs, MemoryNode errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b76fd74bc832ca9c22e9bedadbe2b